### PR TITLE
Enable SSL library detection via PQsslAttribute()

### DIFF
--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -2581,6 +2581,16 @@ const char *PQsslAttribute(const PGconn *conn, const char *attribute_name);
          </varlistentry>
        </variablelist>
       </para>
+
+      <para>
+       As a special case, the <literal>library</literal> attribute may be
+       queried without an existing connection by passing NULL as the
+       <literal>conn</literal> argument. The historical behavior was to return
+       NULL for any attribute when a NULL <literal>conn</literal> was provided;
+       client programs needing to differentiate between the newer and older
+       implementations may check the
+       <literal>LIBPQ_HAS_SSL_LIBRARY_DETECTION</literal> feature macro.
+      </para>
      </listitem>
     </varlistentry>
 

--- a/src/interfaces/libpq/Makefile
+++ b/src/interfaces/libpq/Makefile
@@ -13,6 +13,7 @@ subdir = src/interfaces/libpq
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
+export with_ssl
 
 PGFILEDESC = "PostgreSQL Access Library"
 

--- a/src/interfaces/libpq/fe-secure-openssl.c
+++ b/src/interfaces/libpq/fe-secure-openssl.c
@@ -1631,13 +1631,13 @@ PQsslAttributeNames(PGconn *conn)
 const char *
 PQsslAttribute(PGconn *conn, const char *attribute_name)
 {
+	if (strcmp(attribute_name, "library") == 0)
+		return "OpenSSL";
+
 	if (!conn)
 		return NULL;
 	if (conn->ssl == NULL)
 		return NULL;
-
-	if (strcmp(attribute_name, "library") == 0)
-		return "OpenSSL";
 
 	if (strcmp(attribute_name, "key_bits") == 0)
 	{

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -36,6 +36,8 @@ extern "C"
 #define LIBPQ_HAS_PIPELINING 1
 /* Indicates presence of PQsetTraceFlags; also new PQtrace output format */
 #define LIBPQ_HAS_TRACE_FLAGS 1
+/* Indicates that PQsslAttribute(NULL, "library") is useful */
+#define LIBPQ_HAS_SSL_LIBRARY_DETECTION 1
 
 /*
  * Option flags for PQcopyResult

--- a/src/interfaces/libpq/t/002_api.pl
+++ b/src/interfaces/libpq/t/002_api.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+# Copyright (c) 2022, PostgreSQL Global Development Group
+
+use strict;
+use warnings;
+
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Test PQsslAttribute(NULL, "library")
+my ($out, $err) = run_command(['testclient', '--ssl']);
+
+if ($ENV{with_ssl} eq 'openssl')
+{
+	is($out, 'OpenSSL', 'PQsslAttribute(NULL, "library") returns "OpenSSL"');
+}
+else
+{
+	is($err, 'SSL is not enabled', 'PQsslAttribute(NULL, "library") returns NULL');
+}
+
+done_testing();

--- a/src/interfaces/libpq/test/.gitignore
+++ b/src/interfaces/libpq/test/.gitignore
@@ -1,1 +1,2 @@
+/testclient
 /uri-regress

--- a/src/interfaces/libpq/test/Makefile
+++ b/src/interfaces/libpq/test/Makefile
@@ -11,7 +11,7 @@ endif
 override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
 LDFLAGS_INTERNAL += $(libpq_pgport)
 
-PROGS = uri-regress
+PROGS = testclient uri-regress
 
 all: $(PROGS)
 

--- a/src/interfaces/libpq/test/testclient.c
+++ b/src/interfaces/libpq/test/testclient.c
@@ -1,0 +1,37 @@
+/*
+ * testclient.c
+ *		A test program for the libpq public API
+ *
+ * Copyright (c) 2022, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *		src/interfaces/libpq/test/testclient.c
+ */
+
+#include "postgres_fe.h"
+
+#include "libpq-fe.h"
+
+static void
+print_ssl_library()
+{
+	const char *lib = PQsslAttribute(NULL, "library");
+
+	if (!lib)
+		fprintf(stderr, "SSL is not enabled\n");
+	else
+		printf("%s\n", lib);
+}
+
+int
+main(int argc, char *argv[])
+{
+	if ((argc > 1) && !strcmp(argv[1], "--ssl"))
+	{
+		print_ssl_library();
+		return 0;
+	}
+
+	printf("currently only --ssl is supported\n");
+	return 1;
+}


### PR DESCRIPTION
Currently, libpq client code must have a connection handle before it can
query the "library" SSL attribute. This poses problems if the client
needs to know what SSL library is in use before constructing a
connection string. (For example, with the NSS proposal, a client would
have to decide whether to use the "ssldatabase" connection setting
rather than "sslcert" et al.)

Allow PQsslAttribute(NULL, "library") to return the library in use --
currently, just "OpenSSL" or NULL. The new behavior is announced with
the LIBPQ_HAS_SSL_LIBRARY_DETECTION feature macro, allowing clients to
differentiate between a libpq that was compiled without SSL support and
a libpq that's just too old to tell.