### PR TITLE
Use snprintf instead of sprintf in pg_regress.

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -845,7 +845,7 @@ initialize_environment(void)
 		{
 			char		s[16];
 
-			sprintf(s, "%d", port);
+			snprintf(s, sizeof(s), "%d", port);
 			setenv("PGPORT", s, 1);
 		}
 	}
@@ -867,7 +867,7 @@ initialize_environment(void)
 		{
 			char		s[16];
 
-			sprintf(s, "%d", port);
+			snprintf(s, sizeof(s), "%d", port);
 			setenv("PGPORT", s, 1);
 		}
 		if (user != NULL)


### PR DESCRIPTION
To avoid static analyzers sounding the alarm, move to using snprintf instead of sprintf. This was an oversight in 66d6086cbcbfc8dee789a6.

Reported-by: Tom Lane <tgl@sss.pgh.pa.us>
Discussion: https://postgr.es/m/849588.1698179694@sss.pgh.pa.us