### PR TITLE
Don't remove initdb template when initdb fails

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3116,7 +3116,8 @@ sys.exit(sp.returncode)
 ''',
        test_initdb_template,
        temp_install_bindir / 'initdb',
-       '-A', 'trust', '-N', '--no-instructions', '--no-locale'
+       '--auth', 'trust', '--no-sync', '--no-instructions', '--no-locale',
+       '--no-clean'
      ],
      priority: setup_tests_priority - 1,
      timeout: 300,

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -423,7 +423,7 @@ ifeq ($(MAKELEVEL),0)
 	$(MAKE) -C '$(top_builddir)' DESTDIR='$(abs_top_builddir)'/tmp_install install >'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
 	$(MAKE) -j1 $(if $(CHECKPREP_TOP),-C $(CHECKPREP_TOP),) checkprep >>'$(abs_top_builddir)'/tmp_install/log/install.log 2>&1
 
-	$(with_temp_install) initdb -A trust -N --no-instructions --no-locale '$(abs_top_builddir)'/tmp_install/initdb-template >>'$(abs_top_builddir)'/tmp_install/log/initdb-template.log 2>&1
+	$(with_temp_install) initdb --auth trust --no-sync --no-instructions --no-locale --no-clean '$(abs_top_builddir)'/tmp_install/initdb-template >>'$(abs_top_builddir)'/tmp_install/log/initdb-template.log 2>&1
 endif
 endif
 endif


### PR DESCRIPTION
pg_regress doesn't do that either, so keep a copy around to allow us to debug those issues.

While we're here, use the long options for initdb, to make this code more self-documenting.

Reviewed-by: Daniel Gustafsson