### PR TITLE
Cache typarray for fast lookups in binary upgrade mode

### DIFF
--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -200,6 +200,7 @@ typedef struct _typeInfo
 	const char *rolname;
 	Oid			typelem;
 	Oid			typrelid;
+	Oid			typarray;
 	char		typrelkind;		/* 'r', 'v', 'c', etc */
 	char		typtype;		/* 'b', 'c', etc */
 	bool		isArray;		/* true if auto-generated array type */


### PR DESCRIPTION
When upgrading a large schema it adds significant overhead to perform individual catalog lookups per relation in order to retrieve Oid for preserving Oid calls. This instead adds the typarray to the TypeInfo cache which then allows for fast lookups using the existing API.