### PR TITLE
Fix tiny memory leaks

### DIFF
--- a/src/backend/commands/variable.c
+++ b/src/backend/commands/variable.c
@@ -1092,6 +1092,8 @@ check_application_name(char **newval, void **extra, GucSource source)
 		return false;
 	}
 
+	guc_free(*newval);
+
 	pfree(clean);
 	*newval = ret;
 	return true;
@@ -1127,6 +1129,8 @@ check_cluster_name(char **newval, void **extra, GucSource source)
 		pfree(clean);
 		return false;
 	}
+
+	guc_free(*newval);
 
 	pfree(clean);
 	*newval = ret;


### PR DESCRIPTION
Memory for (*newval) allocated earlier
in the parse_and_validate_value() method.
Since this method re-allocates memory,
it is necessary to free the previously allocated memory.