### PR TITLE
Add ldapscheme to pg_hba_file_rules

### DIFF
--- a/src/backend/utils/adt/hbafuncs.c
+++ b/src/backend/utils/adt/hbafuncs.c
@@ -89,6 +89,10 @@ get_hba_options(HbaLine *hba)
 			options[noptions++] =
 				CStringGetTextDatum(psprintf("ldapport=%d", hba->ldapport));
 
+		if (hba->ldapscheme)
+			options[noptions++] =
+				CStringGetTextDatum(psprintf("ldapscheme=%s", hba->ldapscheme));
+
 		if (hba->ldaptls)
 			options[noptions++] =
 				CStringGetTextDatum("ldaptls=true");


### PR DESCRIPTION
That option was forgotten in the pg_hba_file_rules() function. This fixes bug #18769.  Backpatch all the way.

Author: Laurenz Albe
Discussion: https://postgr.es/m/513a15b5ff69d6023b57e78bbcf5a7c17180cedc.camel@cybertec.at