### PR TITLE
Add X25519 to the default set of curves

### DIFF
--- a/doc/src/sgml/config.sgml
+++ b/doc/src/sgml/config.sgml
@@ -1520,7 +1520,7 @@ include_dir 'conf.d'
         It does not need to be the same curve used by the server's Elliptic
         Curve key.  This parameter can only be set in the
         <filename>postgresql.conf</filename> file or on the server command line.
-        The default is <literal>prime256v1</literal>.
+        The default is <literal>X25519:prime256v1</literal>.
        </para>
 
        <para>

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -4768,7 +4768,7 @@ struct config_string ConfigureNamesString[] =
 		},
 		&SSLECDHCurve,
 #ifdef USE_SSL
-		"prime256v1",
+		"X25519:prime256v1",
 #else
 		"none",
 #endif

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -114,7 +114,7 @@
 #ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL'	# allowed TLSv1.2 ciphers
 #ssl_tls13_ciphers = ''	# allowed TLSv1.3 cipher suites, blank for default
 #ssl_prefer_server_ciphers = on
-#ssl_groups = 'prime256v1'
+#ssl_groups = 'X25519:prime256v1'
 #ssl_min_protocol_version = 'TLSv1.2'
 #ssl_max_protocol_version = ''
 #ssl_dh_params_file = ''

--- a/src/test/ssl/t/SSL/Server.pm
+++ b/src/test/ssl/t/SSL/Server.pm
@@ -301,7 +301,7 @@ sub switch_server_cert
 	$node->append_conf('sslconfig.conf', "ssl=on");
 	$node->append_conf('sslconfig.conf', $backend->set_server_cert(\%params));
 	# use lists of ECDH curves and cipher suites for syntax testing
-	$node->append_conf('sslconfig.conf', 'ssl_groups=prime256v1:secp521r1');
+	$node->append_conf('sslconfig.conf', 'ssl_groups=X25519:prime256v1:secp521r1');
 	$node->append_conf('sslconfig.conf',
 		'ssl_tls13_ciphers=TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256');
 


### PR DESCRIPTION
Since many clients default to the X25519 curve in the TLS handshake, the fact that the server by defualt doesn't support it cause an extra roundtrip for each TLS connection.  By adding multiple curves, which is supported since 3d1ef3a15c3eb68da, we can reduce the risk of extra roundtrips.

Reported-by: Andres Freund <andres@anarazel.de>
Discussion: https://postgr.es/m/20240616234612.6cslu7nqexquvwj7@awork3.anarazel.de