### PR TITLE
Fix sslkeylogfile error handling logging

### DIFF
--- a/src/test/ssl/t/001_ssltests.pl
+++ b/src/test/ssl/t/001_ssltests.pl
@@ -173,6 +173,13 @@ SKIP:
 	ok( (@status = stat("$tempdir/key.txt")),
 		"keylog file exists and returned status");
 	ok(@status && !($status[2] & 0006), "keylog file is not world readable");
+
+	# Connect should work with an incorrect sslkeylogfile, with the error to
+	# open the logfile printed to stderr
+	$node->connect_ok(
+		"$common_connstr sslrootcert=ssl/root+server_ca.crt sslkeylogfile=$tempdir/invalid/key.txt sslmode=require",
+		"connect with server root cert and incorrect sslkeylogfile path",
+		expected_stderr => qr/could not open/);
 }
 
 # The server should not accept non-SSL connections.


### PR DESCRIPTION
When sslkeylogfile has been set but the file fails to open in an otherwise successful connection, the log entry added to the conn object is never printed.  Instead print the error on stderr for increased visibility.  This is a debugging tool so using stderr for logging is appropriate.  Also while there, remove the umask call in the callback as it's not useful.

Issues noted by Peter Eisentraut in post-commit review.

Author: Daniel Gustafsson <daniel@yesql.se>
Reported-by: Peter Eisentraut <peter@eisentraut.org>
Reviewed-by: Peter Eisentraut <peter@eisentraut.org>
Discussion: https://postgr.es/m/70450bee-cfaa-48ce-8980-fc7efcfebb03@eisentraut.org