### PR TITLE
Restart BackgroundPsql's timer more nicely.

### DIFF
--- a/doc/src/sgml/images/README
+++ b/doc/src/sgml/images/README
@@ -13,14 +13,14 @@ involve diffable source files.
 These tools are acceptable:
 
 - Graphviz (https://graphviz.org/)
-- Ditaa (http://ditaa.sourceforge.net/)
+- Ditaa v0.11.0 or later (https://github.com/stathissideris/ditaa)
 
 We use SVG as the format for integrating the image into the ultimate
 output formats of the documentation, that is, HTML, PDF, and others.
 Therefore, any tool used needs to be able to produce SVG.
 
-This directory contains makefile rules to build SVG from common input
-formats, using some common styling.
+This directory contains makefile and meson rules to build SVG from common
+input formats, using some common styling.
 
 fixup-svg.xsl applies some postprocessing to the SVG files produced by
 those external tools to address assorted issues.  See comments in

--- a/doc/src/sgml/images/meson.build
+++ b/doc/src/sgml/images/meson.build
@@ -1,0 +1,61 @@
+# doc/src/sgml/images/meson.build
+#
+# see README in this directory about image handling
+
+if not xsltproc_bin.found() or not dot.found() or not ditaa.found()
+  subdir_done()
+endif
+
+image_targets = []
+
+fixup_svg_xsl = files('fixup-svg.xsl')
+
+all_files = [
+  'genetic-algorithm.gv',
+  'gin.gv',
+  'pagelayout.txt',
+  'temporal-entities.txt',
+  'temporal-references.txt',
+]
+
+foreach file : all_files
+
+  str_split = file.split('.')
+  actual_file_name = str_split[0]
+  extension = str_split[1]
+  cur_file = files(file)
+  tmp_name = '@0@.svg.tmp'.format(file)
+  output_name = '@0@.svg'.format(actual_file_name)
+
+  command = []
+  if extension == 'gv'
+    command = [dot, '-T', 'svg', '-o', '@OUTPUT@', '@INPUT@']
+  elif extension == 'txt'
+    command = [ditaa, '-E', '-S', '--svg', '@INPUT@', '@OUTPUT@']
+  else
+    error('Unknown extension: ".@0@" while generating images'.format(extension))
+  endif
+
+  svg_tmp = custom_target(tmp_name,
+    input: cur_file,
+    output: tmp_name,
+    command: command,
+  )
+
+  current_svg = custom_target(output_name,
+    input: svg_tmp,
+    output: output_name,
+    command: [xsltproc_bin,
+      '--nonet',
+      # Use --novalid to avoid loading SVG DTD if a file specifies it, since
+      # it might not be available locally, and we don't need it.
+      '--novalid',
+      '-o', '@OUTPUT@',
+      fixup_svg_xsl,
+      '@INPUT@']
+  )
+
+  image_targets += current_svg
+endforeach
+
+alias_target('images', image_targets)

--- a/doc/src/sgml/meson.build
+++ b/doc/src/sgml/meson.build
@@ -1,5 +1,7 @@
 # Copyright (c) 2022-2026, PostgreSQL Global Development Group
 
+subdir('images')
+
 docs = []
 installdocs = []
 alldocs = []

--- a/meson.build
+++ b/meson.build
@@ -355,6 +355,8 @@ cp = find_program('cp', required: false, native: true)
 xmllint_bin = find_program(get_option('XMLLINT'), native: true, required: false)
 xsltproc_bin = find_program(get_option('XSLTPROC'), native: true, required: false)
 nm = find_program('nm', required: false, native: true)
+ditaa = find_program('ditaa', native: true, required: false)
+dot = find_program('dot', native: true, required: false)
 
 bison_flags = []
 if bison.found()

--- a/src/bin/psql/t/010_tab_completion.pl
+++ b/src/bin/psql/t/010_tab_completion.pl
@@ -77,8 +77,10 @@ close $FH;
 # for possible debugging purposes.
 my $historyfile = "${PostgreSQL::Test::Utils::log_path}/010_psql_history.txt";
 
-# fire up an interactive psql session
+# fire up an interactive psql session and configure it such that each query
+# restarts the timer
 my $h = $node->interactive_psql('postgres', history_file => $historyfile);
+$h->set_query_timer_restart();
 
 # Simple test case: type something and see if psql responds as expected
 sub check_completion
@@ -87,9 +89,6 @@ sub check_completion
 
 	# report test failures from caller location
 	local $Test::Builder::Level = $Test::Builder::Level + 1;
-
-	# restart per-command timer
-	$h->{timeout}->start($PostgreSQL::Test::Utils::timeout_default);
 
 	# send the data to be sent and wait for its result
 	my $out = $h->query_until($pattern, $send);

--- a/src/bin/psql/t/030_pager.pl
+++ b/src/bin/psql/t/030_pager.pl
@@ -70,8 +70,10 @@ $node->safe_psql(
 25 as y,
 26 as z');
 
-# fire up an interactive psql session
+# fire up an interactive psql session and configure it such that each query
+# restarts the timer
 my $h = $node->interactive_psql('postgres');
+$h->set_query_timer_restart();
 
 # set the pty's window size to known values
 # (requires undesirable chumminess with the innards of IPC::Run)
@@ -87,9 +89,6 @@ sub do_command
 
 	# report test failures from caller location
 	local $Test::Builder::Level = $Test::Builder::Level + 1;
-
-	# restart per-command timer
-	$h->{timeout}->start($PostgreSQL::Test::Utils::timeout_default);
 
 	# send the data to be sent and wait for its result
 	my $out = $h->query_until($pattern, $send);


### PR DESCRIPTION
Use BackgroundPsql's published API for automatically restarting its timer for each query, rather than manually reaching into it to achieve the same thing.

010_tab_completion.pl's logic for this predates the invention of BackgroundPsql (and 664d75753 missed the opportunity to make it cleaner).  030_pager.pl copied-and-pasted the code.

Author: Daniel Gustafsson <daniel@yesql.se>
Reviewed-by: Heikki Linnakangas <hlinnaka@iki.fi>
Reviewed-by: Andrew Dunstan <andrew@dunslane.net>
Reviewed-by: Tom Lane <tgl@sss.pgh.pa.us>
Discussion: https://postgr.es/m/1100715.1712265845@sss.pgh.pa.us