### PR TITLE
Serverside SNI support for libpq

### DIFF
--- a/doc/src/sgml/runtime.sgml
+++ b/doc/src/sgml/runtime.sgml
@@ -2468,6 +2468,12 @@ pg_dumpall -p 5432 | psql -d postgres -p 5433
       <entry>client certificate must not be on this list</entry>
      </row>
 
+     <row>
+      <entry><filename>$PGDATA/pg_hosts.conf</filename></entry>
+      <entry>SNI configuration</entry>
+      <entry>defines which certificates to use for which server hostname</entry>
+     </row>
+
     </tbody>
    </tgroup>
   </table>
@@ -2595,6 +2601,123 @@ openssl x509 -req -in server.csr -text -days 365 \
    </para>
   </sect2>
 
+  <sect2 id="ssl-sni">
+   <title>SNI Configuration</title>
+
+   <para>
+    <productname>PostgreSQL</productname> can be configured for Server Name
+    Indication, <acronym>SNI</acronym>, using the <filename>pg_hosts.conf</filename>
+    configuration file. <productname>PostgreSQL</productname> inspects the TLS
+    hostname extension in the SSL connection handshake, and selects the right
+    TLS certificate, key and CA certificate to use for the connection based on
+    the hosts which are defined in <filename>pg_hosts.conf</filename>.
+   </para>
+
+   <para>
+    SNI configuration is defined in the hosts configuration file,
+    <filename>pg_hosts.conf</filename>, which is stored in the cluster's
+    data directory.  The hosts configuration file contains lines of the general
+    forms:
+<synopsis>
+<replaceable>hostname</replaceable> <replaceable>SSL_certificate</replaceable> <replaceable>SSL_key</replaceable> <replaceable>SSL_CA_certificate</replaceable> <replaceable>SSL_passphrase_cmd</replaceable> <replaceable>SSL_passphrase_cmd_reload</replaceable>
+<literal>include</literal> <replaceable>file</replaceable>
+<literal>include_if_exists</literal> <replaceable>file</replaceable>
+<literal>include_dir</literal> <replaceable>directory</replaceable>
+</synopsis>
+    Comments, whitespace and line continuations are handled in the same way as
+    in <filename>pg_hba.conf</filename>.  <replaceable>hostname</replaceable>
+    is matched against the hostname TLS extension in the SSL handshake.
+    <replaceable>SSL_certificate</replaceable>,
+    <replaceable>SSL_key</replaceable>,
+    <replaceable>SSL_CA_certificate</replaceable>,
+    <replaceable>SSL_passphrase_cmd</replaceable>, and
+    <replaceable>SSL_passphrase_cmd_reload</replaceable>
+    are treated like
+    <xref linkend="guc-ssl-cert-file"/>,
+    <xref linkend="guc-ssl-key-file"/>,
+    <xref linkend="guc-ssl-ca-file"/>,
+    <xref linkend="guc-ssl-passphrase-command"/>, and
+    <xref linkend="guc-ssl-passphrase-command-supports-reload"/> respectively.
+    All fields except <replaceable>SSL_CA_certificate</replaceable>,
+    <replaceable>SSL_passphrase_cmd</replaceable> and
+    <replaceable>SSL_passphrase_cmd_reload</replaceable> are required. If
+    <replaceable>SSL_passphrase_cmd</replaceable> is defined but not
+    <replaceable>SSL_passphrase_cmd_reload</replaceable> then the default
+    value for <replaceable>SSL_passphrase_cmd_reload</replaceable> is
+    <literal>off</literal>.
+   </para>
+
+   <para>
+    <replaceable>hostname</replaceable> should either be set to the literal
+    hostname for the connection, <literal>/no_sni/</literal> or <literal>*</literal>.
+    <xref linkend="hostname-values"/> contains details on how these values are
+    used.
+    <table id="hostname-values">
+     <title>Hostname setting values</title>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>Host Entry</entry>
+        <entry>sslsni</entry>
+        <entry>Description</entry>
+       </row>
+      </thead>
+
+      <tbody>
+       <row>
+        <entry><literal>*</literal></entry>
+        <entry>Not required</entry>
+        <entry>
+         Default host, matches all connections.
+        </entry>
+       </row>
+
+       <row>
+        <entry><literal>/no_sni/</literal></entry>
+        <entry>Not allowed</entry>
+        <entry>
+         Certificate and key to use for connections with no
+         <literal>sslsni</literal> defined.
+        </entry>
+       </row>
+
+       <row>
+        <entry><replaceable>hostname</replaceable></entry>
+        <entry>Required</entry>
+        <entry>
+         Certificate and key to use for connections to the host specified in
+         the connection.  Multiple hostnames can be defined by using a comma
+         separated list. The certificate and key will be used for connections
+         to all hosts in the list.
+        </entry>
+       </row>
+      </tbody>
+
+     </tgroup>
+    </table>
+   </para>
+
+   <para>
+    If <filename>pg_hosts.conf</filename> is empty, or missing, then the SSL
+    configuration in <filename>postgresql.conf</filename> will be used for all
+    connections. If <filename>pg_hosts.conf</filename> is non-empty then it
+    will take precedence over certificate and key settings in
+    <filename>postgresql.conf</filename>.
+   </para>
+
+   <para>
+    It is currently not possible to set different <literal>clientname</literal>
+    values for the different certificates.  Any <literal>clientname</literal>
+    setting in <filename>pg_hba.conf</filename> will be applied during
+    authentication regardless of which set of certificates have been loaded
+    via an SNI enabled connection.
+   </para>
+
+   <para>
+    The CRL configuration in <filename>postgresql.conf</filename> is applied
+    on all connections regardless of if they use SNI or not.
+   </para>
+  </sect2>
  </sect1>
 
  <sect1 id="gssapi-enc">

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -221,6 +221,7 @@ endif
 	$(MAKE) -C utils install-data
 	$(INSTALL_DATA) $(srcdir)/libpq/pg_hba.conf.sample '$(DESTDIR)$(datadir)/pg_hba.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/libpq/pg_ident.conf.sample '$(DESTDIR)$(datadir)/pg_ident.conf.sample'
+	$(INSTALL_DATA) $(srcdir)/libpq/pg_hosts.conf.sample '$(DESTDIR)$(datadir)/pg_hosts.conf.sample'
 	$(INSTALL_DATA) $(srcdir)/utils/misc/postgresql.conf.sample '$(DESTDIR)$(datadir)/postgresql.conf.sample'
 
 ifeq ($(with_llvm), yes)
@@ -280,6 +281,7 @@ endif
 	$(MAKE) -C utils uninstall-data
 	rm -f '$(DESTDIR)$(datadir)/pg_hba.conf.sample' \
 	      '$(DESTDIR)$(datadir)/pg_ident.conf.sample' \
+	      '$(DESTDIR)$(datadir)/pg_hosts.conf.sample' \
 	      '$(DESTDIR)$(datadir)/postgresql.conf.sample'
 ifeq ($(with_llvm), yes)
 	$(call uninstall_llvm_module,postgres)

--- a/src/backend/libpq/be-secure-common.c
+++ b/src/backend/libpq/be-secure-common.c
@@ -26,18 +26,24 @@
 #include "common/string.h"
 #include "libpq/libpq.h"
 #include "storage/fd.h"
+#include "utils/guc.h"
+
+static HostsLine *parse_hosts_line(TokenizedAuthLine *tok_line, int elevel);
 
 /*
  * Run ssl_passphrase_command
  *
  * prompt will be substituted for %p.  is_server_start determines the loglevel
- * of error messages.
+ * of error messages from executing the command, the loglevel for failures in
+ * param substitution will be ERROR regardless of is_server_start.  The actual
+ * command used depends on the configuration for the current host.
  *
  * The result will be put in buffer buf, which is of size size.  The return
  * value is the length of the actual result.
  */
 int
-run_ssl_passphrase_command(const char *prompt, bool is_server_start, char *buf, int size)
+run_ssl_passphrase_command(const char *cmd, const char *prompt,
+						   bool is_server_start, char *buf, int size)
 {
 	int			loglevel = is_server_start ? ERROR : LOG;
 	char	   *command;
@@ -49,7 +55,7 @@ run_ssl_passphrase_command(const char *prompt, bool is_server_start, char *buf, 
 	Assert(size > 0);
 	buf[0] = '\0';
 
-	command = replace_percent_placeholders(ssl_passphrase_command, "ssl_passphrase_command", "p", prompt);
+	command = replace_percent_placeholders(cmd, "ssl_passphrase_command", "p", prompt);
 
 	fh = OpenPipeStream(command, "r");
 	if (fh == NULL)
@@ -174,4 +180,234 @@ check_ssl_key_file_permissions(const char *ssl_key_file, bool isServerStart)
 #endif
 
 	return true;
+}
+
+/*
+ * parse_hosts_line
+ *
+ * Parses a loaded line from the pg_hosts.conf configuration and pulls out the
+ * hostname, certificate, key and CA parts in order to build an SNI config in
+ * the TLS backend. Validation of the parsed values is left for the TLS backend
+ * to implement.
+ */
+static HostsLine *
+parse_hosts_line(TokenizedAuthLine *tok_line, int elevel)
+{
+	HostsLine  *parsedline;
+	List	   *tokens;
+	ListCell   *field;
+	AuthToken  *token;
+
+	parsedline = palloc0(sizeof(HostsLine));
+	parsedline->sourcefile = pstrdup(tok_line->file_name);
+	parsedline->linenumber = tok_line->line_num;
+	parsedline->rawline = pstrdup(tok_line->raw_line);
+	parsedline->hostnames = NIL;
+
+	/* Initialize optional fields */
+	parsedline->ssl_passphrase_cmd = NULL;
+	parsedline->ssl_passphrase_reload = false;
+
+	/* Hostname */
+	field = list_head(tok_line->fields);
+	tokens = lfirst(field);
+	foreach_ptr(AuthToken, hostname, tokens)
+	{
+		if ((tokens->length > 1) &&
+			(strcmp(hostname->string, "*") == 0 || strcmp(hostname->string, "/no_sni/") == 0))
+		{
+			ereport(elevel,
+					errcode(ERRCODE_CONFIG_FILE_ERROR),
+					errmsg("default and non-SNI entries cannot be mixed with other entries"),
+					errcontext("line %d of configuration file \"%s\"",
+							   tok_line->line_num, tok_line->file_name));
+			return NULL;
+		}
+
+		parsedline->hostnames = lappend(parsedline->hostnames, pstrdup(hostname->string));
+	}
+
+	/* SSL Certificate (Required) */
+	field = lnext(tok_line->fields, field);
+	if (!field)
+	{
+		ereport(elevel,
+				errcode(ERRCODE_CONFIG_FILE_ERROR),
+				errmsg("missing entry at end of line"),
+				errcontext("line %d of configuration file \"%s\"",
+						   tok_line->line_num, tok_line->file_name));
+		return NULL;
+	}
+	tokens = lfirst(field);
+	if (tokens->length > 1)
+	{
+		ereport(elevel,
+				errcode(ERRCODE_CONFIG_FILE_ERROR),
+				errmsg("multiple values specified for SSL certificate"),
+				errcontext("line %d of configuration file \"%s\"",
+						   tok_line->line_num, tok_line->file_name));
+		return NULL;
+	}
+	token = linitial(tokens);
+	parsedline->ssl_cert = pstrdup(token->string);
+
+	/* SSL key (Required) */
+	field = lnext(tok_line->fields, field);
+	if (!field)
+	{
+		ereport(elevel,
+				errcode(ERRCODE_CONFIG_FILE_ERROR),
+				errmsg("missing entry at end of line"),
+				errcontext("line %d of configuration file \"%s\"",
+						   tok_line->line_num, tok_line->file_name));
+		return NULL;
+	}
+	tokens = lfirst(field);
+	if (tokens->length > 1)
+	{
+		ereport(elevel,
+				errcode(ERRCODE_CONFIG_FILE_ERROR),
+				errmsg("multiple values specified for SSL key"),
+				errcontext("line %d of configuration file \"%s\"",
+						   tok_line->line_num, tok_line->file_name));
+		return NULL;
+	}
+	token = linitial(tokens);
+	parsedline->ssl_key = pstrdup(token->string);
+
+	/* SSL CA (optional) */
+	field = lnext(tok_line->fields, field);
+	if (!field)
+		return parsedline;
+	tokens = lfirst(field);
+	if (tokens->length > 1)
+	{
+		ereport(elevel,
+				errcode(ERRCODE_CONFIG_FILE_ERROR),
+				errmsg("multiple values specified for SSL CA"),
+				errcontext("line %d of configuration file \"%s\"",
+						   tok_line->line_num, tok_line->file_name));
+		return NULL;
+	}
+	token = linitial(tokens);
+	parsedline->ssl_ca = pstrdup(token->string);
+
+	/* SSL Passphrase Command (optional) */
+	field = lnext(tok_line->fields, field);
+	if (field)
+	{
+		tokens = lfirst(field);
+		token = linitial(tokens);
+		parsedline->ssl_passphrase_cmd = pstrdup(token->string);
+
+		/*
+		 * SSL Passphrase Command support reload (optional). This field is
+		 * only supported if there was a passphrase command parsed first, so
+		 * nest it under the previous token.
+		 */
+		field = lnext(tok_line->fields, field);
+		if (field)
+		{
+			tokens = lfirst(field);
+			token = linitial(tokens);
+
+			if (token->string[0] == '1'
+				|| pg_strcasecmp(token->string, "true") == 0
+				|| pg_strcasecmp(token->string, "on") == 0
+				|| pg_strcasecmp(token->string, "yes") == 0)
+				parsedline->ssl_passphrase_reload = true;
+			else if (token->string[0] == '0'
+					 || pg_strcasecmp(token->string, "false") == 0
+					 || pg_strcasecmp(token->string, "off") == 0
+					 || pg_strcasecmp(token->string, "no") == 0)
+				parsedline->ssl_passphrase_reload = false;
+			else
+			{
+				ereport(elevel,
+						errcode(ERRCODE_CONFIG_FILE_ERROR),
+						errmsg("incorrect syntax for boolean value SSL_passphrase_cmd_reload"),
+						errcontext("line %d of configuration file \"%s\"",
+								   tok_line->line_num, tok_line->file_name));
+				return NULL;
+			}
+		}
+	}
+
+	return parsedline;
+}
+
+/*
+ * load_hosts
+ *
+ * Reads and parses the pg_hosts.conf configuration file and passes back a List
+ * of HostsLine elements containing the parsed lines, or NIL in case of an empty
+ * file.  The list is returned in the hosts_lines parameter. If loading the
+ * file was successful, true is returned, else false.  This function is
+ * intended to be executed within a temporary memory context which can be
+ * discarded to free memory allocated during the processing of the file.
+ */
+int
+load_hosts(List **hosts, char **err_msg)
+{
+	FILE	   *file;
+	ListCell   *line;
+	List	   *hosts_lines = NIL;
+	List	   *parsed_lines = NIL;
+	HostsLine  *newline;
+	bool		ok = true;
+
+	/*
+	 * If we cannot return results then error out immediately. This implies
+	 * API misuse or a similar kind of programmer error.
+	 */
+	if (!hosts)
+		return HOSTSFILE_LOAD_FAILED;
+	*hosts = NIL;
+
+	/*
+	 * This is not an auth file per se, but it is using the same file format
+	 * as the pg_hba and pg_ident files and thus the same code infrastructure.
+	 * A future TODO might be to rename the supporting code with a more
+	 * generic name?
+	 */
+	file = open_auth_file(HostsFileName, LOG, 0, err_msg);
+	if (file == NULL)
+	{
+		if (errno == ENOENT)
+			return HOSTSFILE_MISSING;
+
+		return HOSTSFILE_LOAD_FAILED;
+	}
+
+	tokenize_auth_file(HostsFileName, file, &hosts_lines, LOG, 0);
+
+	foreach(line, hosts_lines)
+	{
+		TokenizedAuthLine *tok_line = (TokenizedAuthLine *) lfirst(line);
+
+		/*
+		 * Mark processing as not-ok in case lines are found with errors in
+		 * tokenization (.err_msg is set) or during parsing.
+		 */
+		if ((tok_line->err_msg != NULL) ||
+			((newline = parse_hosts_line(tok_line, LOG)) == NULL))
+		{
+			ok = false;
+			continue;
+		}
+
+		parsed_lines = lappend(parsed_lines, newline);
+	}
+
+	/* Free memory from tokenizer */
+	free_auth_file(file, 0);
+	*hosts = parsed_lines;
+
+	if (!ok)
+		return HOSTSFILE_LOAD_FAILED;
+
+	if (parsed_lines == NIL)
+		return HOSTSFILE_EMPTY;
+
+	return HOSTSFILE_LOAD_OK;
 }

--- a/src/backend/libpq/be-secure-openssl.c
+++ b/src/backend/libpq/be-secure-openssl.c
@@ -73,14 +73,36 @@ static int	alpn_cb(SSL *ssl,
 					const unsigned char *in,
 					unsigned int inlen,
 					void *userdata);
+static int	sni_clienthello_cb(SSL *ssl, int *al, void *arg);
 static bool initialize_dh(SSL_CTX *context, bool isServerStart);
 static bool initialize_ecdh(SSL_CTX *context, bool isServerStart);
 static const char *SSLerrmessageExt(unsigned long ecode, const char *replacement);
 static const char *SSLerrmessage(unsigned long ecode);
+static bool init_host_context(HostsLine *host, bool isServerStart);
+static void host_context_cleanup_cb(void *arg);
 
 static char *X509_NAME_to_cstring(X509_NAME *name);
 
 static SSL_CTX *SSL_context = NULL;
+static MemoryContext SSL_hosts_memcxt = NULL;
+static struct hosts
+{
+	/*
+	 * List of HostsLine structures containing SSL configurations for
+	 * connections with hostnames defined in the SNI extension.
+	 */
+	List	   *sni;
+
+	/* The SSL configuration to use for connections without SNI */
+	HostsLine  *no_sni;
+
+	/*
+	 * The default SSL configuration to use as a fallback in case no hostname
+	 * matches the supplied hostname in the SNI extension.
+	 */
+	HostsLine  *default_host;
+}		   *SSL_hosts;
+
 static bool dummy_ssl_passwd_cb_called = false;
 static bool ssl_is_server_start;
 
@@ -103,9 +125,189 @@ struct CallbackErr
 int
 be_tls_init(bool isServerStart)
 {
-	SSL_CTX    *context;
+	List	   *pg_hosts = NIL;
+	ListCell   *line;
+	MemoryContext oldcxt;
+	MemoryContext host_memcxt = NULL;
+	MemoryContextCallback *host_memcxt_cb;
+	char	   *err_msg;
+	int			res;
+	struct hosts *new_hosts;
+	SSL_CTX    *context = NULL;
 	int			ssl_ver_min = -1;
 	int			ssl_ver_max = -1;
+
+	/*
+	 * Since we don't know which host we're using until the ClientHello is
+	 * sent, ssl_loaded_verify_locations *always* starts out as false. The
+	 * only place it's set to true is in sni_clienthello_cb().
+	 */
+	ssl_loaded_verify_locations = false;
+
+	host_memcxt = AllocSetContextCreate(CurrentMemoryContext,
+										"hosts file parser context",
+										ALLOCSET_SMALL_SIZES);
+	oldcxt = MemoryContextSwitchTo(host_memcxt);
+
+	/* Allocate a tentative replacement for SSL_hosts. */
+	new_hosts = palloc0_object(struct hosts);
+
+	/*
+	 * Register a reset callback for the memory context which is responsible
+	 * for freeing OpenSSL managed allocations upon context deletion.  The
+	 * callback is allocated here to make sure it gets cleaned up along with
+	 * the memory context it's registered for.
+	 */
+	host_memcxt_cb = palloc0_object(MemoryContextCallback);
+	host_memcxt_cb->func = host_context_cleanup_cb;
+	host_memcxt_cb->arg = new_hosts;
+	MemoryContextRegisterResetCallback(host_memcxt, host_memcxt_cb);
+
+	/*
+	 * If ssl_sni is enabled, attempt to load and parse TLS configuration from
+	 * the pg_hosts.conf file with the set of hosts returned as a list.  If
+	 * there are hosts configured they take precedence over the configuration
+	 * in postgresql.conf.  Make sure to allocate the parsed rows in their own
+	 * memory context so that we can delete them easily in case parsing fails.
+	 * If ssl_sni is disabled then set the state accordingly to make sure we
+	 * instead parse the config from postgresql.conf.
+	 *
+	 * The reason for not doing everything in this if-else conditional is that
+	 * we want to use the same processing of postgresql.conf for when ssl_sni
+	 * is off as well as when it's on but the hostsfile is missing etc.  Thus
+	 * we set res to the state and continue with a new conditional instead of
+	 * duplicating logic and risk it diverging over time.
+	 */
+	if (ssl_sni)
+	{
+		res = load_hosts(&pg_hosts, &err_msg);
+
+		/*
+		 * pg_hosts.conf is not required to contain configuration, but if it
+		 * does we error out in case it fails to load rather than continue to
+		 * try the postgresql.conf configuration to avoid silently falling back
+		 * on an undesired configuration.
+		 */
+		if (res == HOSTSFILE_LOAD_FAILED)
+		{
+			ereport(isServerStart ? FATAL : LOG,
+					errcode(ERRCODE_CONFIG_FILE_ERROR),
+					errmsg("could not load \"%s\": %s", "pg_hosts.conf",
+						   err_msg ? err_msg : "unknown error"));
+			goto error;
+		}
+	}
+	else
+		res = HOSTSFILE_DISABLED;
+
+	/*
+	 * Loading and parsing the hosts file was successful, create configs for
+	 * each host entry and add to the list of hosts to be checked during
+	 * login.
+	 */
+	if (res == HOSTSFILE_LOAD_OK)
+	{
+		Assert(ssl_sni);
+
+		foreach(line, pg_hosts)
+		{
+			HostsLine  *host = lfirst(line);
+
+			if (!init_host_context(host, isServerStart))
+				goto error;
+
+			/*
+			 * The hostname in the config will be set to NULL for the default
+			 * host as well as in configs used for non-SNI connections.  Lists
+			 * of hostnames in pg_hosts.conf are not allowed to contain the
+			 * default '*' entry or a '/no_sni/' entry and this is checked
+			 * during parsing.  Thus we can inspect the head of the hostnames
+			 * list for these since they will never be anywhere else.
+			 */
+			if (strcmp(linitial(host->hostnames), "*") == 0)
+			{
+				if (new_hosts->default_host)
+				{
+					ereport(isServerStart ? FATAL : LOG,
+							errcode(ERRCODE_CONFIG_FILE_ERROR),
+							errmsg("multiple default hosts specified"),
+							errcontext("line %d of configuration file \"%s\"",
+									   host->linenumber, host->sourcefile));
+					goto error;
+				}
+
+				new_hosts->default_host = host;
+			}
+			else if (strcmp(linitial(host->hostnames), "/no_sni/") == 0)
+			{
+				if (new_hosts->no_sni)
+				{
+					ereport(isServerStart ? FATAL : LOG,
+							errcode(ERRCODE_CONFIG_FILE_ERROR),
+							errmsg("multiple no_sni hosts specified"),
+							errcontext("line %d of configuration file \"%s\"",
+									   host->linenumber, host->sourcefile));
+					goto error;
+				}
+
+				new_hosts->no_sni = host;
+			}
+			else
+			{
+				/*
+				 * At this point we know we have a configuration with a list
+				 * of 1..n hostnames for literal string matching with the SNI
+				 * extension from the user.
+				 */
+				new_hosts->sni = lappend(new_hosts->sni, host);
+			}
+		}
+	}
+
+	/*
+	 * If SNI is disabled, then we load configuration from postgresql.conf. If
+	 * SNI is enabled but the pg_hosts.conf file doesn't exist, or is empty,
+	 * then we also load the config from postgresql.conf.
+	 */
+	else if (res == HOSTSFILE_DISABLED || res == HOSTSFILE_EMPTY || res == HOSTSFILE_MISSING)
+	{
+		HostsLine  *pgconf = palloc0(sizeof(HostsLine));
+
+#ifdef USE_ASSERT_CHECKING
+		if (res == HOSTSFILE_DISABLED)
+			Assert(ssl_sni == false);
+#endif
+
+		pgconf->ssl_cert = ssl_cert_file;
+		pgconf->ssl_key = ssl_key_file;
+		pgconf->ssl_ca = ssl_ca_file;
+		pgconf->ssl_passphrase_cmd = ssl_passphrase_command;
+		pgconf->ssl_passphrase_reload = ssl_passphrase_command_supports_reload;
+
+		if (!init_host_context(pgconf, isServerStart))
+			goto error;
+
+		/*
+		 * If postgresql.conf is used to configure SSL then by definition it
+		 * will be the default context as we don't have per-host config.
+		 */
+		new_hosts->default_host = pgconf;
+	}
+
+	/*
+	 * Make sure we have at least one configuration loaded to use, without
+	 * that we cannot drive a connection so exit.
+	 */
+	if (new_hosts->sni == NIL && !new_hosts->default_host && !new_hosts->no_sni)
+	{
+		ereport(isServerStart ? FATAL : LOG,
+				errcode(ERRCODE_CONFIG_FILE_ERROR),
+				errmsg("no SSL configurations loaded"),
+				/*- translator: The two %s contain filenames */
+				errhint("If ssl_sni is enabled then add configuration to \"%s\", else \"%s\"",
+						"pg_hosts.conf", "postgresql.conf"));
+		goto error;
+	}
 
 	/*
 	 * Create a new SSL context into which we'll load all the configuration
@@ -136,55 +338,6 @@ be_tls_init(bool isServerStart)
 	 * Call init hook (usually to set password callback)
 	 */
 	(*openssl_tls_init_hook) (context, isServerStart);
-
-	/* used by the callback */
-	ssl_is_server_start = isServerStart;
-
-	/*
-	 * Load and verify server's certificate and private key
-	 */
-	if (SSL_CTX_use_certificate_chain_file(context, ssl_cert_file) != 1)
-	{
-		ereport(isServerStart ? FATAL : LOG,
-				(errcode(ERRCODE_CONFIG_FILE_ERROR),
-				 errmsg("could not load server certificate file \"%s\": %s",
-						ssl_cert_file, SSLerrmessage(ERR_get_error()))));
-		goto error;
-	}
-
-	if (!check_ssl_key_file_permissions(ssl_key_file, isServerStart))
-		goto error;
-
-	/*
-	 * OK, try to load the private key file.
-	 */
-	dummy_ssl_passwd_cb_called = false;
-
-	if (SSL_CTX_use_PrivateKey_file(context,
-									ssl_key_file,
-									SSL_FILETYPE_PEM) != 1)
-	{
-		if (dummy_ssl_passwd_cb_called)
-			ereport(isServerStart ? FATAL : LOG,
-					(errcode(ERRCODE_CONFIG_FILE_ERROR),
-					 errmsg("private key file \"%s\" cannot be reloaded because it requires a passphrase",
-							ssl_key_file)));
-		else
-			ereport(isServerStart ? FATAL : LOG,
-					(errcode(ERRCODE_CONFIG_FILE_ERROR),
-					 errmsg("could not load private key file \"%s\": %s",
-							ssl_key_file, SSLerrmessage(ERR_get_error()))));
-		goto error;
-	}
-
-	if (SSL_CTX_check_private_key(context) != 1)
-	{
-		ereport(isServerStart ? FATAL : LOG,
-				(errcode(ERRCODE_CONFIG_FILE_ERROR),
-				 errmsg("check of private key failed: %s",
-						SSLerrmessage(ERR_get_error()))));
-		goto error;
-	}
 
 	if (ssl_min_protocol_version)
 	{
@@ -323,19 +476,167 @@ be_tls_init(bool isServerStart)
 		SSL_CTX_set_options(context, SSL_OP_CIPHER_SERVER_PREFERENCE);
 
 	/*
+	 * Success!  Replace any existing SSL_context and host configurations.
+	 */
+	if (SSL_context)
+		SSL_CTX_free(SSL_context);
+
+	MemoryContextSwitchTo(oldcxt);
+
+	if (SSL_hosts_memcxt)
+		MemoryContextDelete(SSL_hosts_memcxt);
+
+	SSL_hosts_memcxt = host_memcxt;
+	SSL_hosts = new_hosts;
+	SSL_context = context;
+
+	return 0;
+
+	/*
+	 * Clean up by releasing working SSL contexts as well as allocations
+	 * perfornmed during parsing.  Since all our allocations are done in a
+	 * local memory context all we need to do is delete it.
+	 */
+error:
+	if (context)
+		SSL_CTX_free(context);
+
+	MemoryContextSwitchTo(oldcxt);
+	MemoryContextDelete(host_memcxt);
+	return -1;
+}
+
+/*
+ * host_context_cleanup_cb
+ *
+ * Memory context reset callback for clearing OpenSSL managed resources when
+ * hosts are reloaded and the previous set of configured hosts are freed. As
+ * all hosts are allocated in a single context we don't need to free each host
+ * individually, just resources managed by OpenSSL.
+ */
+static void
+host_context_cleanup_cb(void *arg)
+{
+	struct hosts *hosts = arg;
+
+	foreach_ptr(HostsLine, host, hosts->sni)
+	{
+		if (host->ssl_ctx != NULL)
+			SSL_CTX_free(host->ssl_ctx);
+	}
+
+	if (hosts->no_sni && hosts->no_sni->ssl_ctx)
+		SSL_CTX_free(hosts->no_sni->ssl_ctx);
+
+	if (hosts->default_host && hosts->default_host->ssl_ctx)
+		SSL_CTX_free(hosts->default_host->ssl_ctx);
+}
+
+static bool
+init_host_context(HostsLine *host, bool isServerStart)
+{
+	SSL_CTX    *ctx = SSL_CTX_new(SSLv23_method());
+
+	if (!ctx)
+	{
+		ereport(isServerStart ? FATAL : LOG,
+				(errmsg("could not create SSL context: %s",
+						SSLerrmessage(ERR_get_error()))));
+		goto error;
+	}
+
+	/*
+	 * Load and verify server's certificate and private key
+	 */
+	if (SSL_CTX_use_certificate_chain_file(ctx, host->ssl_cert) != 1)
+	{
+		ereport(isServerStart ? FATAL : LOG,
+				(errcode(ERRCODE_CONFIG_FILE_ERROR),
+				 errmsg("could not load server certificate file \"%s\": %s",
+						host->ssl_cert, SSLerrmessage(ERR_get_error()))));
+		goto error;
+	}
+
+	if (!check_ssl_key_file_permissions(host->ssl_key, isServerStart))
+		goto error;
+
+	/*
+	 * Set up the password callback, if configured.
+	 */
+	if (isServerStart)
+	{
+		if (host->ssl_passphrase_cmd && host->ssl_passphrase_cmd[0])
+		{
+			SSL_CTX_set_default_passwd_cb(ctx, ssl_external_passwd_cb);
+			SSL_CTX_set_default_passwd_cb_userdata(ctx, host->ssl_passphrase_cmd);
+		}
+	}
+	else
+	{
+		if (host->ssl_passphrase_reload && host->ssl_passphrase_cmd[0])
+		{
+			SSL_CTX_set_default_passwd_cb(ctx, ssl_external_passwd_cb);
+			SSL_CTX_set_default_passwd_cb_userdata(ctx, host->ssl_passphrase_cmd);
+		}
+		else
+
+			/*
+			 * If reloading and no external command is configured, override
+			 * OpenSSL's default handling of passphrase-protected files,
+			 * because we don't want to prompt for a passphrase in an
+			 * already-running server.
+			 */
+			SSL_CTX_set_default_passwd_cb(ctx, dummy_ssl_passwd_cb);
+	}
+
+	/* used by the callback */
+	ssl_is_server_start = isServerStart;
+
+	/*
+	 * OK, try to load the private key file.
+	 */
+	dummy_ssl_passwd_cb_called = false;
+
+	if (SSL_CTX_use_PrivateKey_file(ctx,
+									host->ssl_key,
+									SSL_FILETYPE_PEM) != 1)
+	{
+		if (dummy_ssl_passwd_cb_called)
+			ereport(isServerStart ? FATAL : LOG,
+					(errcode(ERRCODE_CONFIG_FILE_ERROR),
+					 errmsg("private key file \"%s\" cannot be reloaded because it requires a passphrase",
+							host->ssl_key)));
+		else
+			ereport(isServerStart ? FATAL : LOG,
+					(errcode(ERRCODE_CONFIG_FILE_ERROR),
+					 errmsg("could not load private key file \"%s\": %s",
+							host->ssl_key, SSLerrmessage(ERR_get_error()))));
+		goto error;
+	}
+
+	if (SSL_CTX_check_private_key(ctx) != 1)
+	{
+		ereport(isServerStart ? FATAL : LOG,
+				(errcode(ERRCODE_CONFIG_FILE_ERROR),
+				 errmsg("check of private key failed: %s",
+						SSLerrmessage(ERR_get_error()))));
+		goto error;
+	}
+
+	/*
 	 * Load CA store, so we can verify client certificates if needed.
 	 */
-	if (ssl_ca_file[0])
+	if (host->ssl_ca && host->ssl_ca[0])
 	{
 		STACK_OF(X509_NAME) * root_cert_list;
 
-		if (SSL_CTX_load_verify_locations(context, ssl_ca_file, NULL) != 1 ||
-			(root_cert_list = SSL_load_client_CA_file(ssl_ca_file)) == NULL)
+		if (SSL_CTX_load_verify_locations(ctx, host->ssl_ca, NULL) != 1 ||
+			(root_cert_list = SSL_load_client_CA_file(host->ssl_ca)) == NULL)
 		{
 			ereport(isServerStart ? FATAL : LOG,
 					(errcode(ERRCODE_CONFIG_FILE_ERROR),
 					 errmsg("could not load root certificate file \"%s\": %s",
-							ssl_ca_file, SSLerrmessage(ERR_get_error()))));
+							host->ssl_ca, SSLerrmessage(ERR_get_error()))));
 			goto error;
 		}
 
@@ -346,17 +647,7 @@ be_tls_init(bool isServerStart)
 		 * that the SSL context will "own" the root_cert_list and remember to
 		 * free it when no longer needed.
 		 */
-		SSL_CTX_set_client_CA_list(context, root_cert_list);
-
-		/*
-		 * Always ask for SSL client cert, but don't fail if it's not
-		 * presented.  We might fail such connections later, depending on what
-		 * we find in pg_hba.conf.
-		 */
-		SSL_CTX_set_verify(context,
-						   (SSL_VERIFY_PEER |
-							SSL_VERIFY_CLIENT_ONCE),
-						   verify_cb);
+		SSL_CTX_set_client_CA_list(ctx, root_cert_list);
 	}
 
 	/*----------
@@ -366,7 +657,7 @@ be_tls_init(bool isServerStart)
 	 */
 	if (ssl_crl_file[0] || ssl_crl_dir[0])
 	{
-		X509_STORE *cvstore = SSL_CTX_get_cert_store(context);
+		X509_STORE *cvstore = SSL_CTX_get_cert_store(ctx);
 
 		if (cvstore)
 		{
@@ -407,29 +698,13 @@ be_tls_init(bool isServerStart)
 		}
 	}
 
-	/*
-	 * Success!  Replace any existing SSL_context.
-	 */
-	if (SSL_context)
-		SSL_CTX_free(SSL_context);
+	host->ssl_ctx = ctx;
+	return true;
 
-	SSL_context = context;
-
-	/*
-	 * Set flag to remember whether CA store has been loaded into SSL_context.
-	 */
-	if (ssl_ca_file[0])
-		ssl_loaded_verify_locations = true;
-	else
-		ssl_loaded_verify_locations = false;
-
-	return 0;
-
-	/* Clean up by releasing working context. */
 error:
-	if (context)
-		SSL_CTX_free(context);
-	return -1;
+	if (ctx)
+		SSL_CTX_free(ctx);
+	return false;
 }
 
 void
@@ -467,6 +742,13 @@ be_tls_open_server(Port *port)
 
 	/* enable ALPN */
 	SSL_CTX_set_alpn_select_cb(SSL_context, alpn_cb, port);
+
+	/*
+	 * Install SNI TLS extension callback in order to validate hostnames in
+	 * case ssl_sni has been enabled.  If ssl_sni is disabled we still use
+	 * the callback to immediately assign the default context.
+	 */
+	SSL_CTX_set_client_hello_cb(SSL_context, sni_clienthello_cb, NULL);
 
 	if (!(port->ssl = SSL_new(SSL_context)))
 	{
@@ -1141,10 +1423,11 @@ ssl_external_passwd_cb(char *buf, int size, int rwflag, void *userdata)
 {
 	/* same prompt as OpenSSL uses internally */
 	const char *prompt = "Enter PEM pass phrase:";
+	const char *cmd = userdata;
 
 	Assert(rwflag == 0);
 
-	return run_ssl_passphrase_command(prompt, ssl_is_server_start, buf, size);
+	return run_ssl_passphrase_command(cmd, prompt, ssl_is_server_start, buf, size);
 }
 
 /*
@@ -1390,6 +1673,255 @@ alpn_cb(SSL *ssl,
 	}
 }
 
+/*
+ * ssl_update_ssl
+ *
+ * Replace certificate/key and CA in an SSL object to match the, via the SNI
+ * extension, selected host configuration for the connection.  The SSL_CTX
+ * object to use should be passed in as ctx.  This function will update the
+ * SSL object in-place.
+ */
+static bool
+ssl_update_ssl(SSL *ssl, HostsLine *host_config)
+{
+	SSL_CTX    *ctx = host_config->ssl_ctx;
+
+	X509	   *cert;
+	EVP_PKEY   *key;
+
+	STACK_OF(X509) * chain;
+
+	Assert(ctx != NULL);
+	/*-
+	 * Make use of the already-loaded certificate chain and key. At first
+	 * glance, SSL_set_SSL_CTX() looks like the easiest way to do this, but
+	 * beware -- it has very odd behavior:
+	 *
+	 *     https://github.com/openssl/openssl/issues/6109
+	 */
+	cert = SSL_CTX_get0_certificate(ctx);
+	key = SSL_CTX_get0_privatekey(ctx);
+
+	Assert(cert && key);
+
+	if (!SSL_CTX_get0_chain_certs(ctx, &chain)
+		|| !SSL_use_cert_and_key(ssl, cert, key, chain, 1 /* override */ )
+		|| !SSL_check_private_key(ssl))
+	{
+		/*
+		 * This shouldn't really be possible, since the inputs came from a
+		 * SSL_CTX that was already populated by OpenSSL.
+		 */
+		ereport(COMMERROR,
+				errcode(ERRCODE_INTERNAL_ERROR),
+				errmsg_internal("could not update certificate chain: %s",
+								SSLerrmessage(ERR_get_error())));
+		return false;
+	}
+
+	if (host_config->ssl_ca && host_config->ssl_ca[0])
+	{
+		/*
+		 * Copy the trust store and list of roots over from the SSL_CTX.
+		 */
+		X509_STORE *ca_store = SSL_CTX_get_cert_store(ctx);
+
+		STACK_OF(X509_NAME) * roots;
+
+		/*
+		 * The trust store appears to be the only setting that this function
+		 * can't override via the (SSL *) pointer directly. Instead, share it
+		 * with the active SSL_CTX (this should always be SSL_context).
+		 */
+		Assert(SSL_context == SSL_get_SSL_CTX(ssl));
+		SSL_CTX_set1_cert_store(SSL_context, ca_store);
+
+		/*
+		 * TODO: test that the new locations don't stack with prior CA config;
+		 * that's CVE-worthy
+		 *
+		 * TODO: test interactions with CRLs.
+		 */
+
+		/*
+		 * SSL_set_client_CA_list() will take ownership of its argument, so we
+		 * need to duplicate it.
+		 */
+		if ((roots = SSL_CTX_get_client_CA_list(ctx)) == NULL
+			|| (roots = SSL_dup_CA_list(roots)) == NULL)
+		{
+			ereport(COMMERROR,
+					errcode(ERRCODE_INTERNAL_ERROR),
+					errmsg_internal("could not duplicate SSL_CTX CA list: %s",
+									SSLerrmessage(ERR_get_error())));
+			return false;
+		}
+
+		SSL_set_client_CA_list(ssl, roots);
+
+		/*
+		 * Always ask for SSL client cert, but don't fail if it's not
+		 * presented.  We might fail such connections later, depending on what
+		 * we find in pg_hba.conf.
+		 */
+		SSL_set_verify(ssl,
+					   (SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE),
+					   verify_cb);
+
+		ssl_loaded_verify_locations = true;
+	}
+
+	return true;
+}
+
+/*
+ * sni_clienthello_cb
+ *
+ * Callback for extracting the servername extension from the TLS handshake
+ * during ClientHello.  There is a callback in OpenSSL for the servername
+ * specifically but OpenSSL themselves advice against using it as it is more
+ * dependent on ordering for execution.
+ */
+static int
+sni_clienthello_cb(SSL *ssl, int *al, void *arg)
+{
+	const char *tlsext_hostname;
+	const unsigned char *tlsext;
+	size_t		left,
+				len;
+	HostsLine  *install_config = NULL;
+
+	if (!ssl_sni)
+	{
+		install_config = SSL_hosts->default_host;
+		goto found;
+	}
+
+	if (SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_server_name, &tlsext, &left))
+	{
+		if (left <= 2)
+		{
+			*al = SSL_AD_MISSING_EXTENSION;
+			return 0;
+		}
+		len = (*(tlsext++) << 8);
+		len += *(tlsext)++;
+		if (len + 2 != left)
+		{
+			*al = SSL_AD_MISSING_EXTENSION;
+			return 0;
+		}
+
+		left = len;
+
+		if (left == 0 || *tlsext++ != TLSEXT_NAMETYPE_host_name)
+		{
+			*al = SSL_AD_MISSING_EXTENSION;
+			return 0;
+		}
+
+		left--;
+
+		/*
+		 * Now we can finally pull out the byte array with the actual
+		 * hostname.
+		 */
+		if (left <= 2)
+		{
+			*al = SSL_AD_MISSING_EXTENSION;
+			return 0;
+		}
+		len = (*(tlsext++) << 8);
+		len += *(tlsext++);
+		if (len + 2 > left)
+		{
+			*al = SSL_AD_MISSING_EXTENSION;
+			return 0;
+		}
+		left = len;
+		tlsext_hostname = (const char *) tlsext;
+
+		/*
+		 * We have a requested hostname from the client, match against all
+		 * entries in the pg_hosts configuration and attempt to find a match.
+		 * Matching is done case insensitive as per RFC 952 and RFC 921.
+		 */
+		foreach_ptr(HostsLine, host, SSL_hosts->sni)
+		{
+			foreach_ptr(char, hostname, host->hostnames)
+			{
+				if (strlen(hostname) == len &&
+					pg_strncasecmp(hostname, tlsext_hostname, len) == 0)
+				{
+					install_config = host;
+					goto found;
+				}
+			}
+		}
+
+		/*
+		 * If no host specific match was found, and there is a default config,
+		 * then fall back to using that.
+		 */
+		if (!install_config && SSL_hosts->default_host)
+			install_config = SSL_hosts->default_host;
+	}
+	/*
+	 * No hostname TLS extension in the handshake, use the default or no_sni
+	 * configurations if available.
+	 */
+	else
+	{
+		if (SSL_hosts->no_sni)
+			install_config = SSL_hosts->no_sni;
+		else if (SSL_hosts->default_host)
+			install_config = SSL_hosts->default_host;
+		else
+		{
+			/*
+			 * Reaching here means that we didn't get a hostname in the TLS
+			 * extension and the server has been configured to not allow any
+			 * connections without a specified hostname.
+			 *
+			 * The error message for a missing server_name should, according
+			 * to RFC 8446, be missing_extension. This isn't entirely ideal
+			 * since the user won't be able to tell which extension the server
+			 * considered missing.  Sending unrecognized_name would be a more
+			 * helpful error, but for now we stick to the RFC.
+			 */
+			*al = SSL_AD_MISSING_EXTENSION;
+
+			ereport(COMMERROR,
+					(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					 errmsg("no hostname provided in callback, and no fallback configured")));
+			return SSL_CLIENT_HELLO_ERROR;
+		}
+	}
+
+	/*
+	 * If we reach here without a context chosen as the session context then
+	 * fail the handshake and terminate the connection.
+	 */
+	if (install_config == NULL)
+	{
+		if (tlsext_hostname)
+			*al = SSL_AD_UNRECOGNIZED_NAME;
+		else
+			*al = SSL_AD_MISSING_EXTENSION;
+		return SSL_CLIENT_HELLO_ERROR;
+	}
+
+found:
+	if (!ssl_update_ssl(ssl, install_config))
+	{
+		ereport(COMMERROR,
+				errcode(ERRCODE_PROTOCOL_VIOLATION),
+				errmsg("failed to switch to SSL configuration for host, terminating connection"));
+		return SSL_CLIENT_HELLO_ERROR;
+	}
+
+	return SSL_CLIENT_HELLO_SUCCESS;
+}
 
 /*
  * Set DH parameters for generating ephemeral DH keys.  The
@@ -1791,18 +2323,28 @@ ssl_protocol_version_to_string(int v)
 }
 
 
+/*
+ * TODO: this no longer makes sense. We don't use SSL_context to load the
+ * private key any more. Where should the init hook go, and what should it do?
+ */
 static void
 default_openssl_tls_init(SSL_CTX *context, bool isServerStart)
 {
 	if (isServerStart)
 	{
 		if (ssl_passphrase_command[0])
+		{
 			SSL_CTX_set_default_passwd_cb(context, ssl_external_passwd_cb);
+			SSL_CTX_set_default_passwd_cb_userdata(context, ssl_passphrase_command);
+		}
 	}
 	else
 	{
 		if (ssl_passphrase_command[0] && ssl_passphrase_command_supports_reload)
+		{
 			SSL_CTX_set_default_passwd_cb(context, ssl_external_passwd_cb);
+			SSL_CTX_set_default_passwd_cb_userdata(context, ssl_passphrase_command);
+		}
 		else
 
 			/*

--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -61,6 +61,9 @@ bool		SSLPreferServerCiphers;
 int			ssl_min_protocol_version = PG_TLS1_2_VERSION;
 int			ssl_max_protocol_version = PG_TLS_ANY;
 
+/* GUC variable: if false, discards hostname extensions in handshake */
+bool		ssl_sni = false;
+
 /* ------------------------------------------------------------ */
 /*			 Procedures common to all secure sessions			*/
 /* ------------------------------------------------------------ */

--- a/src/backend/libpq/meson.build
+++ b/src/backend/libpq/meson.build
@@ -31,5 +31,6 @@ endif
 install_data(
   'pg_hba.conf.sample',
   'pg_ident.conf.sample',
+  'pg_hosts.conf.sample',
   install_dir: dir_data,
 )

--- a/src/backend/libpq/pg_hosts.conf.sample
+++ b/src/backend/libpq/pg_hosts.conf.sample
@@ -1,0 +1,4 @@
+# PostgreSQL SNI Hostname mappings
+# ================================
+
+# HOSTNAME       SSL CERTIFICATE             SSL KEY     SSL CA       PASSPHRASE COMMAND         PASSPHRASE COMMAND RELOAD

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -56,6 +56,7 @@
 #define CONFIG_FILENAME "postgresql.conf"
 #define HBA_FILENAME	"pg_hba.conf"
 #define IDENT_FILENAME	"pg_ident.conf"
+#define HOSTS_FILENAME	"pg_hosts.conf"
 
 #ifdef EXEC_BACKEND
 #define CONFIG_EXEC_PARAMS "global/config_exec_params"
@@ -1837,6 +1838,36 @@ SelectConfigFiles(const char *userDoption, const char *progname)
 		goto fail;
 	}
 	SetConfigOption("ident_file", fname, PGC_POSTMASTER, PGC_S_OVERRIDE);
+
+	if (fname_is_malloced)
+		free(fname);
+	else
+		guc_free(fname);
+
+	/*
+	 * Likewise for pg_hosts.conf.
+	 */
+	if (HostsFileName)
+	{
+		fname = make_absolute_path(HostsFileName);
+		fname_is_malloced = true;
+	}
+	else if (configdir)
+	{
+		fname = guc_malloc(FATAL,
+						   strlen(configdir) + strlen(HOSTS_FILENAME) + 2);
+		sprintf(fname, "%s/%s", configdir, HOSTS_FILENAME);
+		fname_is_malloced = false;
+	}
+	else
+	{
+		write_stderr("%s does not know where to find the \"hosts\" configuration file.\n"
+					 "This can be specified as \"hosts_file\" in \"%s\", "
+					 "or by the -D invocation option, or by the "
+					 "PGDATA environment variable.\n",
+					 progname, ConfigFileName);
+	}
+	SetConfigOption("hosts_file", fname, PGC_POSTMASTER, PGC_S_OVERRIDE);
 
 	if (fname_is_malloced)
 		free(fname);

--- a/src/backend/utils/misc/guc_parameters.dat
+++ b/src/backend/utils/misc/guc_parameters.dat
@@ -1177,6 +1177,13 @@
   boot_val => 'NULL',
 },
 
+{ name => 'hosts_file', type => 'string', context => 'PGC_POSTMASTER', group => 'FILE_LOCATIONS',
+  short_desc => 'Sets the server\'s "hosts" configuration file.',
+  flags => 'GUC_SUPERUSER_ONLY',
+  variable => 'HostsFileName',
+  boot_val => 'NULL',
+},
+
 { name => 'hot_standby', type => 'bool', context => 'PGC_POSTMASTER', group => 'REPLICATION_STANDBY',
   short_desc => 'Allows connections and queries during recovery.',
   variable => 'EnableHotStandby',
@@ -2762,6 +2769,13 @@
   boot_val => '0',
   min => '0',
   max => '0',
+},
+
+{ name => 'ssl_sni', type => 'bool', context => 'PGC_SIGHUP', group => 'CONN_AUTH_SSL',
+  short_desc => 'Sets whether to interpret SNI extensions in SSL connections.',
+  flags => 'GUC_SUPERUSER_ONLY',
+  variable => 'ssl_sni',
+  boot_val => 'false',
 },
 
 { name => 'ssl_tls13_ciphers', type => 'string', context => 'PGC_SIGHUP', group => 'CONN_AUTH_SSL',

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -565,6 +565,7 @@ char	   *cluster_name = "";
 char	   *ConfigFileName;
 char	   *HbaFileName;
 char	   *IdentFileName;
+char	   *HostsFileName;
 char	   *external_pid_file;
 
 char	   *application_name;

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -45,6 +45,8 @@
                                         # (change requires restart)
 #ident_file = 'ConfigDir/pg_ident.conf' # ident configuration file
                                         # (change requires restart)
+#hosts_file = 'ConfigDir/pg_hosts.conf' # hosts configuration file
+                                        # (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
 #external_pid_file = ''                 # write an extra PID file
@@ -122,6 +124,7 @@
 #ssl_dh_params_file = ''
 #ssl_passphrase_command = ''
 #ssl_passphrase_command_supports_reload = off
+#ssl_sni = off
 
 
 #------------------------------------------------------------------------------

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -177,6 +177,7 @@ static int	encodingid;
 static char *bki_file;
 static char *hba_file;
 static char *ident_file;
+static char *hosts_file;
 static char *conf_file;
 static char *dictionary_file;
 static char *info_schema_file;
@@ -1533,6 +1534,14 @@ setup_config(void)
 	if (chmod(path, pg_file_create_mode) != 0)
 		pg_fatal("could not change permissions of \"%s\": %m", path);
 
+	/* pg_hosts.conf */
+	conflines = readfile(hosts_file);
+	snprintf(path, sizeof(path), "%s/pg_hosts.conf", pg_data);
+
+	writefile(path, conflines);
+	if (chmod(path, pg_file_create_mode) != 0)
+		pg_fatal("could not change permissions of \"%s\": %m", path);
+
 	check_ok();
 }
 
@@ -2790,6 +2799,7 @@ setup_data_file_paths(void)
 	set_input(&bki_file, "postgres.bki");
 	set_input(&hba_file, "pg_hba.conf.sample");
 	set_input(&ident_file, "pg_ident.conf.sample");
+	set_input(&hosts_file, "pg_hosts.conf.sample");
 	set_input(&conf_file, "postgresql.conf.sample");
 	set_input(&dictionary_file, "snowball_create.sql");
 	set_input(&info_schema_file, "information_schema.sql");
@@ -2805,12 +2815,12 @@ setup_data_file_paths(void)
 				"PGDATA=%s\nshare_path=%s\nPGPATH=%s\n"
 				"POSTGRES_SUPERUSERNAME=%s\nPOSTGRES_BKI=%s\n"
 				"POSTGRESQL_CONF_SAMPLE=%s\n"
-				"PG_HBA_SAMPLE=%s\nPG_IDENT_SAMPLE=%s\n",
+				"PG_HBA_SAMPLE=%s\nPG_IDENT_SAMPLE=%s\nPG_HOSTS_SAMPLE=%s\n",
 				PG_VERSION,
 				pg_data, share_path, bin_path,
 				username, bki_file,
 				conf_file,
-				hba_file, ident_file);
+				hba_file, ident_file, hosts_file);
 		if (show_setting)
 			exit(0);
 	}
@@ -2818,6 +2828,7 @@ setup_data_file_paths(void)
 	check_input(bki_file);
 	check_input(hba_file);
 	check_input(ident_file);
+	check_input(hosts_file);
 	check_input(conf_file);
 	check_input(dictionary_file);
 	check_input(info_schema_file);

--- a/src/include/libpq/hba.h
+++ b/src/include/libpq/hba.h
@@ -151,6 +151,36 @@ typedef struct IdentLine
 	AuthToken  *pg_user;
 } IdentLine;
 
+typedef struct HostsLine
+{
+	int			linenumber;
+
+	char	   *sourcefile;
+	char	   *rawline;
+
+	/* Required fields */
+	List	   *hostnames;
+	char	   *ssl_key;
+	char	   *ssl_cert;
+
+	/* Optional fields */
+	char	   *ssl_ca;
+	char	   *ssl_passphrase_cmd;
+	bool		ssl_passphrase_reload;
+
+	/* Internal bookkeeping */
+	void	   *ssl_ctx;		/* associated SSL_CTX* for the above settings */
+} HostsLine;
+
+typedef enum HostsFileLoad
+{
+	HOSTSFILE_LOAD_OK = 0,
+	HOSTSFILE_LOAD_FAILED,
+	HOSTSFILE_EMPTY,
+	HOSTSFILE_MISSING,
+	HOSTSFILE_DISABLED,
+} HostsFileLoadResult;
+
 /*
  * TokenizedAuthLine represents one line lexed from an authentication
  * configuration file.  Each item in the "fields" list is a sub-list of

--- a/src/include/libpq/libpq.h
+++ b/src/include/libpq/libpq.h
@@ -113,6 +113,7 @@ extern PGDLLIMPORT int ssl_max_protocol_version;
 extern PGDLLIMPORT char *ssl_passphrase_command;
 extern PGDLLIMPORT bool ssl_passphrase_command_supports_reload;
 extern PGDLLIMPORT char *ssl_dh_params_file;
+extern PGDLLIMPORT bool ssl_sni;
 extern PGDLLIMPORT char *SSLCipherSuites;
 extern PGDLLIMPORT char *SSLCipherList;
 extern PGDLLIMPORT char *SSLECDHCurve;
@@ -158,9 +159,11 @@ enum ssl_protocol_versions
 /*
  * prototypes for functions in be-secure-common.c
  */
-extern int	run_ssl_passphrase_command(const char *prompt, bool is_server_start,
+extern int	run_ssl_passphrase_command(const char *cmd, const char *prompt,
+									   bool is_server_start,
 									   char *buf, int size);
 extern bool check_ssl_key_file_permissions(const char *ssl_key_file,
 										   bool isServerStart);
+extern int	load_hosts(List **hosts, char **err_msg);
 
 #endif							/* LIBPQ_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -312,6 +312,7 @@ extern PGDLLIMPORT char *cluster_name;
 extern PGDLLIMPORT char *ConfigFileName;
 extern PGDLLIMPORT char *HbaFileName;
 extern PGDLLIMPORT char *IdentFileName;
+extern PGDLLIMPORT char *HostsFileName;
 extern PGDLLIMPORT char *external_pid_file;
 
 extern PGDLLIMPORT char *application_name;

--- a/src/test/ssl/meson.build
+++ b/src/test/ssl/meson.build
@@ -13,6 +13,7 @@ tests += {
       't/001_ssltests.pl',
       't/002_scram.pl',
       't/003_sslinfo.pl',
+      't/004_sni.pl',
     ],
   },
 }

--- a/src/test/ssl/t/001_ssltests.pl
+++ b/src/test/ssl/t/001_ssltests.pl
@@ -380,11 +380,11 @@ switch_server_cert($node, certfile => 'server-ip-cn-only');
 $common_connstr =
   "$default_ssl_connstr user=ssltestuser dbname=trustdb sslrootcert=ssl/root+server_ca.crt hostaddr=$SERVERHOSTADDR sslmode=verify-full";
 
-$node->connect_ok("$common_connstr host=192.0.2.1",
+$node->connect_ok("$common_connstr host=192.0.2.1 sslsni=0",
 	"IP address in the Common Name");
 
 $node->connect_fails(
-	"$common_connstr host=192.000.002.001",
+	"$common_connstr host=192.000.002.001 sslsni=0",
 	"mismatch between host name and server certificate IP address",
 	expected_stderr =>
 	  qr/\Qserver certificate for "192.0.2.1" does not match host name "192.000.002.001"\E/
@@ -394,7 +394,7 @@ $node->connect_fails(
 # long-standing behavior.)
 switch_server_cert($node, certfile => 'server-ip-in-dnsname');
 
-$node->connect_ok("$common_connstr host=192.0.2.1",
+$node->connect_ok("$common_connstr host=192.0.2.1 sslsni=0",
 	"IP address in a dNSName");
 
 # Test Subject Alternative Names.
@@ -1003,5 +1003,44 @@ $node->connect_fails(
 		qr{Client certificate verification failed at depth 0: certificate revoked},
 		qr{Failed certificate data \(unverified\): subject "/CN=\\xce\\x9f\\xce\\xb4\\xcf\\x85\\xcf\\x83\\xcf\\x83\\xce\\xad\\xce\\xb1\\xcf\\x82", serial number \d+, issuer "/CN=Test CA for PostgreSQL SSL regression test client certs"},
 	]);
+
+# Test client CAs
+my $connstr =
+  "user=ssltestuser dbname=certdb hostaddr=$SERVERHOSTADDR sslmode=require sslsni=1";
+
+switch_server_cert($node, certfile => 'server-cn-only', cafile => '');
+# example.org is unconfigured and should fail.
+$node->connect_fails(
+	"$connstr host=example.org sslcertmode=require sslcert=ssl/client.crt"
+	  . sslkey('client.key'),
+	"host: 'example.org', ca: '': connect with sslcert, no client CA configured",
+	expected_stderr => qr/client certificates can only be checked if a root certificate store is available/);
+
+# example.com uses the client CA.
+switch_server_cert($node, certfile => 'server-cn-only', cafile => 'root+client_ca');
+# example.com is configured and should require a valid client cert.
+$node->connect_fails(
+	"$connstr host=example.com sslcertmode=disable",
+	"host: 'example.com', ca: 'root+client_ca.crt': connect fails if no client certificate sent",
+	expected_stderr => qr/connection requires a valid client certificate/);
+$node->connect_ok(
+	"$connstr host=example.com sslcertmode=require sslcert=ssl/client.crt " . sslkey('client.key'),
+	"host: 'example.com', ca: 'root+client_ca.crt': connect with sslcert, client certificate sent"
+);
+
+# example.net uses the server CA (which is wrong).
+switch_server_cert($node, certfile => 'server-cn-only', cafile => 'root+server_ca');
+# example.net is configured and should require a client cert, but will
+# always fail verification.
+$node->connect_fails(
+	"$connstr host=example.net sslcertmode=disable",
+	"host: 'example.net', ca: 'root+server_ca.crt': connect fails if no client certificate sent",
+	expected_stderr => qr/connection requires a valid client certificate/);
+
+$node->connect_fails(
+	"$connstr host=example.net sslcertmode=require sslcert=ssl/client.crt "
+	  . sslkey('client.key'),
+	"host: 'example.net', ca: 'root+server_ca.crt': connect with sslcert, client certificate sent",
+	expected_stderr => qr/unknown ca/);
 
 done_testing();

--- a/src/test/ssl/t/004_sni.pl
+++ b/src/test/ssl/t/004_sni.pl
@@ -1,0 +1,383 @@
+
+# Copyright (c) 2024, PostgreSQL Global Development Group
+
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+use FindBin;
+use lib $FindBin::RealBin;
+
+use SSL::Server;
+
+# This is the hostaddr used to connect to the server. This cannot be a
+# hostname, because the server certificate is always for the domain
+# postgresql-ssl-regression.test.
+my $SERVERHOSTADDR = '127.0.0.1';
+# This is the pattern to use in pg_hba.conf to match incoming connections.
+my $SERVERHOSTCIDR = '127.0.0.1/32';
+
+if ($ENV{with_ssl} ne 'openssl')
+{
+	plan skip_all => 'OpenSSL not supported by this build';
+}
+
+if (!$ENV{PG_TEST_EXTRA} || $ENV{PG_TEST_EXTRA} !~ /\bssl\b/)
+{
+	plan skip_all =>
+	  'Potentially unsafe test SSL not enabled in PG_TEST_EXTRA';
+}
+
+my $ssl_server = SSL::Server->new();
+
+my $node = PostgreSQL::Test::Cluster->new('primary');
+$node->init;
+
+# PGHOST is enforced here to set up the node, subsequent connections
+# will use a dedicated connection string.
+$ENV{PGHOST} = $node->host;
+$ENV{PGPORT} = $node->port;
+$node->start;
+
+$ssl_server->configure_test_server_for_ssl($node, $SERVERHOSTADDR,
+	$SERVERHOSTCIDR, 'trust');
+
+$ssl_server->switch_server_cert($node, certfile => 'server-cn-only');
+
+my $connstr =
+  "user=ssltestuser dbname=trustdb hostaddr=$SERVERHOSTADDR sslsni=1";
+
+##############################################################################
+# postgresql.conf
+##############################################################################
+
+# Connect without any hosts configured in pg_hosts.conf, thus using the cert
+# and key in postgresql.conf. pg_hosts.conf exists at this point but is empty
+# apart from the comments stemming from the sample.
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require",
+	"pg.conf: connect with correct server CA cert file sslmode=require");
+
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg.conf: connect fails without intermediate for sslmode=verify-ca",
+	expected_stderr => qr/certificate verify failed/);
+
+# Add an entry in pg_hosts.conf with no default, and reload. Since ssl_sni is
+# still 'off' we should still be able to connect using the certificates in
+# postgresql.conf
+$node->append_conf('pg_hosts.conf',
+	"example.org server-cn-only.crt server-cn-only.key");
+$node->reload;
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require",
+	"pg.conf: connect with correct server CA cert file sslmode=require");
+
+# Turn on SNI support and remove pg_hosts.conf and reload to make sure a
+# missing file is treated like an empty file.
+$node->append_conf('postgresql.conf', 'ssl_sni = on');
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->reload;
+
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require",
+	"pg.conf: connect after deleting pg_hosts.conf");
+
+##############################################################################
+# pg_hosts.conf
+##############################################################################
+
+# Replicate the postgresql.conf configuration into pg_hosts.conf and retry the
+# same tests as above.
+$node->append_conf('pg_hosts.conf',
+	"* server-cn-only.crt server-cn-only.key");
+$node->reload;
+
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require",
+	"pg_hosts.conf: connect to default, with correct server CA cert file sslmode=require"
+);
+
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to default, fail without intermediate for sslmode=verify-ca",
+	expected_stderr => qr/certificate verify failed/);
+
+# Add host entry for example.org which serves the server cert and its
+# intermediate CA.  The previously existing default host still exists without
+# a CA.
+$node->append_conf('pg_hosts.conf',
+	"example.org server-cn-only+server_ca.crt server-cn-only.key root_ca.crt"
+);
+$node->reload;
+
+$node->connect_ok(
+	"$connstr host=example.org sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to example.org and verify server CA");
+
+$node->connect_ok(
+	"$connstr host=Example.ORG sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to Example.ORG and verify server CA");
+
+$node->connect_fails(
+	"$connstr host=example.org sslrootcert=invalid sslmode=verify-ca",
+	"pg_hosts.conf: connect to example.org but without server root cert, sslmode=verify-ca",
+	expected_stderr => qr/root certificate file "invalid" does not exist/);
+
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to default and fail to verify CA",
+	expected_stderr => qr/certificate verify failed/);
+
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require",
+	"pg_hosts.conf: connect to default with sslmode=require");
+
+# Use multiple hostnames for a single configuration
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	"example.org,example.com,example.net server-cn-only+server_ca.crt server-cn-only.key root_ca.crt"
+);
+$node->reload;
+
+$node->connect_ok(
+	"$connstr host=example.org sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to example.org and verify server CA");
+$node->connect_ok(
+	"$connstr host=example.com sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to example.com and verify server CA");
+$node->connect_ok(
+	"$connstr host=example.net sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	"pg_hosts.conf: connect to example.net and verify server CA");
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=example.se",
+	"pg_hosts.conf: connect to default with sslmode=require",
+	expected_stderr => qr/unrecognized name/);
+
+# Test @-inclusion of hostnames.
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	'example.org,@hostnames.txt server-cn-only+server_ca.crt server-cn-only.key root_ca.crt'
+);
+$node->append_conf('hostnames.txt', qq{
+example.com
+example.net
+});
+$node->reload;
+
+$node->connect_ok(
+	"$connstr host=example.org sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	'@hostnames.txt: connect to example.org and verify server CA');
+$node->connect_ok(
+	"$connstr host=example.com sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	'@hostnames.txt: connect to example.com and verify server CA');
+$node->connect_ok(
+	"$connstr host=example.net sslrootcert=ssl/root_ca.crt sslmode=verify-ca",
+	'@hostnames.txt: connect to example.net and verify server CA');
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=example.se",
+	'@hostnames.txt: connect to default with sslmode=require',
+	expected_stderr => qr/unrecognized name/);
+
+# Add an incorrect entry specifying a default entry combined with hostnames
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	"example.org,*,example.net server-cn-only+server_ca.crt server-cn-only.key root_ca.crt"
+);
+my $result = $node->restart(fail_ok => 1);
+is($result, 0,
+	'pg_hosts.conf: restart fails with default entry combined with hostnames'
+);
+
+# Add incorrect duplicate entries.
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf(
+	'pg_hosts.conf', qq{
+* server-cn-only.crt server-cn-only.key
+* server-cn-only.crt server-cn-only.key
+});
+$result = $node->restart(fail_ok => 1);
+is($result, 0, 'pg_hosts.conf: restart fails with two default entries');
+
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf(
+	'pg_hosts.conf', qq{
+/no_sni/ server-cn-only.crt server-cn-only.key
+/no_sni/ server-cn-only.crt server-cn-only.key
+});
+$result = $node->restart(fail_ok => 1);
+is($result, 0, 'pg_hosts.conf: restart fails with two no_sni entries');
+
+# TODO: duplicate SNI hostnames?
+
+# Modify pg_hosts.conf to no longer have the default host entry.
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	"example.org server-cn-only+server_ca.crt server-cn-only.key root_ca.crt"
+);
+$node->restart;
+
+# Connecting without a hostname as well as with a hostname which isn't in the
+# pg_hosts configuration should fail.
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require sslsni=0",
+	"pg_hosts.conf: connect to default with sslmode=require",
+	expected_stderr => qr/handshake failure/);
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=example.com",
+	"pg_hosts.conf: connect to default with sslmode=require",
+	expected_stderr => qr/unrecognized name/);
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=example",
+	"pg_hosts.conf: connect to 'example' with sslmode=require",
+	expected_stderr => qr/unrecognized name/);
+
+# Reconfigure with broken configuration for the key passphrase, the server
+# should not start up
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	'localhost server-cn-only.crt server-password.key root+client_ca.crt "echo wrongpassword" on'
+);
+$result = $node->restart(fail_ok => 1);
+is($result, 0,
+	'pg_hosts.conf: restart fails with password-protected key when using the wrong passphrase command'
+);
+
+# Reconfigure again but with the correct passphrase set
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	'localhost server-cn-only.crt server-password.key root+client_ca.crt "echo secret1" on'
+);
+$result = $node->restart(fail_ok => 1);
+is($result, 1,
+	'pg_hosts.conf: restart succeeds with password-protected key when using the correct passphrase command'
+);
+
+# Make sure connecting works, and try to stress the reload logic by issuing
+# subsequent reloads
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=localhost",
+	"pg_hosts.conf: connect with correct server CA cert file sslmode=require"
+);
+$node->reload;
+$node->reload;
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=localhost",
+	"pg_hosts.conf: connect with correct server CA cert file after reloads");
+$node->reload;
+$node->reload;
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=localhost",
+	"pg_hosts.conf: connect with correct server CA cert file after more reloads"
+);
+
+# Test reloading a passphrase protected key without reloading support in the
+# passphrase hook. Restarting should not give any errors in the log, but the
+# subsequent reload should fail with an error regarding reloading.
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	'localhost server-cn-only.crt server-password.key root+client_ca.crt "echo secret1" off'
+);
+my $node_loglocation = -s $node->logfile;
+$result = $node->restart(fail_ok => 1);
+is($result, 1,
+	'pg_hosts.conf: restart succeeds with password-protected key when using the correct passphrase command'
+);
+my $log = PostgreSQL::Test::Utils::slurp_file($node->logfile, $node_loglocation);
+unlike($log, qr/cannot be reloaded because it requires a passphrase/,
+	 'log reload failure due to passphrase command reloading');
+
+SKIP:
+{
+	# Passphrase reloads must be enabled on Windows to succeed even without a
+	# restart
+	skip "Passphrase command reload required on Windows", 1 if ($windows_os);
+
+	$node->connect_ok(
+		"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=localhost",
+		"pg_hosts.conf: connect with correct server CA cert file sslmode=require"
+	);
+	# Reloading should fail since the passphrase cannot be reloaded, with an
+	# error recorded in the log.  Since we keep existing contexts around it
+	# should still work.
+	$node_loglocation = -s $node->logfile;
+	$node->reload;
+	$node->connect_ok(
+		"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=localhost",
+		"pg_hosts.conf: connect with correct server CA cert file sslmode=require"
+	);
+	$log = PostgreSQL::Test::Utils::slurp_file($node->logfile, $node_loglocation);
+	like($log,
+		 qr/cannot be reloaded because it requires a passphrase/,
+		 'log reload failure due to passphrase command reloading');
+}
+
+# Configure with only non-SNI connections allowed
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+$node->append_conf('pg_hosts.conf',
+	"/no_sni/ server-cn-only.crt server-cn-only.key");
+$node->restart;
+
+$node->connect_ok(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require sslsni=0",
+	"pg_hosts.conf: only non-SNI connections allowed");
+
+$node->connect_fails(
+	"$connstr sslrootcert=ssl/root+server_ca.crt sslmode=require host=example.org",
+	"pg_hosts.conf: only non-SNI connections allowed, connecting with SNI",
+	expected_stderr => qr/unrecognized name/);
+
+# Test client CAs
+
+# pg_hosts configuration
+ok(unlink($node->data_dir . '/pg_hosts.conf'));
+# example.org has an unconfigured CA.
+$node->append_conf('pg_hosts.conf',
+	'example.org server-cn-only.crt server-cn-only.key');
+# example.com uses the client CA.
+$node->append_conf('pg_hosts.conf',
+	'example.com server-cn-only.crt server-cn-only.key root+client_ca.crt');
+# example.net uses the server CA (which is wrong).
+$node->append_conf('pg_hosts.conf',
+	'example.net server-cn-only.crt server-cn-only.key root+server_ca.crt');
+$node->restart;
+
+$connstr =
+  "user=ssltestuser dbname=certdb hostaddr=$SERVERHOSTADDR sslmode=require sslsni=1";
+
+# example.org is unconfigured and should fail.
+$node->connect_fails(
+	"$connstr host=example.org sslcertmode=require sslcert=ssl/client.crt"
+	  . $ssl_server->sslkey('client.key'),
+	"host: 'example.org', ca: '': connect with sslcert, no client CA configured",
+	expected_stderr => qr/client certificates can only be checked if a root certificate store is available/);
+
+# example.com is configured and should require a valid client cert.
+$node->connect_fails(
+	"$connstr host=example.com sslcertmode=disable",
+	"host: 'example.com', ca: 'root+client_ca.crt': connect fails if no client certificate sent",
+	expected_stderr => qr/connection requires a valid client certificate/);
+
+$node->connect_ok(
+	"$connstr host=example.com sslcertmode=require sslcert=ssl/client.crt "
+	  . $ssl_server->sslkey('client.key'),
+	"host: 'example.com', ca: 'root+client_ca.crt': connect with sslcert, client certificate sent"
+);
+
+# example.net is configured and should require a client cert, but will
+# always fail verification.
+$node->connect_fails(
+	"$connstr host=example.net sslcertmode=disable",
+	"host: 'example.net', ca: 'root+server_ca.crt': connect fails if no client certificate sent",
+	expected_stderr => qr/connection requires a valid client certificate/);
+
+$node->connect_fails(
+	"$connstr host=example.net sslcertmode=require sslcert=ssl/client.crt "
+	  . $ssl_server->sslkey('client.key'),
+	"host: 'example.net', ca: 'root+server_ca.crt': connect with sslcert, client certificate sent",
+	expected_stderr => qr/unknown ca/);
+
+done_testing();

--- a/src/test/ssl/t/SSL/Backend/OpenSSL.pm
+++ b/src/test/ssl/t/SSL/Backend/OpenSSL.pm
@@ -72,6 +72,7 @@ sub init
 	chmod(0600, glob "$pgdata/server-*.key")
 	  or die "failed to change permissions on server keys: $!";
 	_copy_files("ssl/root+client_ca.crt", $pgdata);
+	_copy_files("ssl/root+server_ca.crt", $pgdata);
 	_copy_files("ssl/root_ca.crt", $pgdata);
 	_copy_files("ssl/root+client.crl", $pgdata);
 	mkdir("$pgdata/root+client-crldir")
@@ -146,7 +147,8 @@ following parameters are supported:
 =item cafile => B<value>
 
 The CA certificate file to use for the C<ssl_ca_file> GUC. If omitted it will
-default to 'root+client_ca.crt'.
+default to 'root+client_ca.crt'. If empty, no C<ssl_ca_file> configuration
+parameter will be set.
 
 =item certfile => B<value>
 
@@ -181,10 +183,18 @@ sub set_server_cert
 	  unless defined $params->{keyfile};
 
 	my $sslconf =
-		"ssl_ca_file='$params->{cafile}.crt'\n"
-	  . "ssl_cert_file='$params->{certfile}.crt'\n"
+		"ssl_cert_file='$params->{certfile}.crt'\n"
 	  . "ssl_key_file='$params->{keyfile}.key'\n"
 	  . "ssl_crl_file='$params->{crlfile}'\n";
+	if ($params->{cafile} ne "")
+	{
+		$sslconf .= "ssl_ca_file='$params->{cafile}.crt'\n";
+	}
+	else
+	{
+		$sslconf .= "ssl_ca_file=''\n";
+	}
+
 	$sslconf .= "ssl_crl_dir='$params->{crldir}'\n"
 	  if defined $params->{crldir};
 

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1227,6 +1227,8 @@ HeapTupleHeader
 HeapTupleHeaderData
 HeapTupleTableSlot
 HistControl
+HostsFileLoadResult
+HostsLine
 HotStandbyState
 I32
 ICU_Convert_Func


### PR DESCRIPTION
Support for SNI was added to clientside libpq in 5c55dc8b4733 with the sslsni parameter, but there was no support for utilizing it serverside. This adds support for serverside SNI such that certificate/key handling is available per host.  A new config file, $datadir/pg_hosts.conf, is used for configuring which certificate and key should be used for which hostname.  If pg_hosts.conf is non-empty it will take precedence over the regular SSL GUCs, if it is empty or missing the regular GUCs will be used just as before this commit with no hostname specific handling.

Host configuration can either be for a literal hostname to match, non- SNI connections using the no_sni keyword or a default fallback matching all connections.  By omitting no_sni and the fallback a strict mode can be achieved where only connections using sslsni=1 and a specified hostname are allowed.

CRL file(s) are applied from postgresql.conf to all configured hostnames.

Author: Daniel Gustafsson <daniel@yesql.se>

Reviewed-by: Jacob Champion <jacob.champion@enterprisedb.com>
Reviewed-by: Chao Li <li.evan.chao@gmail.com>
Reviewed-by: Dewei Dai <daidewei1970@163.com>
Reviewed-by: Cary Huang <cary.huang@highgo.ca>
Reviewed-by: Heikki Linnakangas <hlinnaka@iki.fi>
Discussion: https://postgr.es/m/1C81CD0D-407E-44F9-833A-DD0331C202E5@yesql.se