### PR TITLE
Online enabling and disabling of data checksums

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -4836,7 +4836,7 @@ SetDataChecksumsOn(void)
 
 	/*
 	 * Await state transition to "on" in all backends. When done we know that
-	 * data data checksums are both written and verified in all backends.
+	 * data checksums are both written and verified in all backends.
 	 */
 	WaitForProcSignalBarrier(barrier);
 }
@@ -4864,7 +4864,7 @@ SetDataChecksumsOff(void)
 	SpinLockAcquire(&XLogCtl->info_lck);
 
 	/* If data checksums are already disabled there is nothing to do */
-	if (XLogCtl->data_checksum_version == 0)
+	if (XLogCtl->data_checksum_version == PG_DATA_CHECKSUM_OFF)
 	{
 		SpinLockRelease(&XLogCtl->info_lck);
 		return;
@@ -4931,7 +4931,7 @@ SetDataChecksumsOff(void)
 	XLogChecksums(PG_DATA_CHECKSUM_OFF);
 
 	SpinLockAcquire(&XLogCtl->info_lck);
-	XLogCtl->data_checksum_version = 0;
+	XLogCtl->data_checksum_version = PG_DATA_CHECKSUM_OFF;
 	SpinLockRelease(&XLogCtl->info_lck);
 
 	barrier = EmitProcSignalBarrier(PROCSIGNAL_BARRIER_CHECKSUM_OFF);
@@ -6605,7 +6605,7 @@ StartupXLOG(void)
 		XLogChecksums(PG_DATA_CHECKSUM_OFF);
 
 		SpinLockAcquire(&XLogCtl->info_lck);
-		XLogCtl->data_checksum_version = 0;
+		XLogCtl->data_checksum_version = PG_DATA_CHECKSUM_OFF;
 		SetLocalDataChecksumState(XLogCtl->data_checksum_version);
 		SpinLockRelease(&XLogCtl->info_lck);
 
@@ -6625,7 +6625,7 @@ StartupXLOG(void)
 		XLogChecksums(PG_DATA_CHECKSUM_OFF);
 
 		SpinLockAcquire(&XLogCtl->info_lck);
-		XLogCtl->data_checksum_version = 0;
+		XLogCtl->data_checksum_version = PG_DATA_CHECKSUM_OFF;
 		SetLocalDataChecksumState(XLogCtl->data_checksum_version);
 		SpinLockRelease(&XLogCtl->info_lck);
 	}

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -241,7 +241,7 @@ BootstrapModeMain(int argc, char *argv[], bool check_only)
 	pg_getopt_ctx optctx;
 	int			flag;
 	char	   *userDoption = NULL;
-	uint32		bootstrap_data_checksum_version = 0;	/* No checksum */
+	uint32		bootstrap_data_checksum_version = PG_DATA_CHECKSUM_OFF;
 	yyscan_t	scanner;
 
 	Assert(!IsUnderPostmaster);

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -589,7 +589,7 @@ main(int argc, char *argv[])
 		mode == PG_MODE_CHECK)
 		pg_fatal("data checksums are not enabled in cluster");
 
-	if (ControlFile->data_checksum_version == 0 &&
+	if (ControlFile->data_checksum_version == PG_DATA_CHECKSUM_OFF &&
 		mode == PG_MODE_DISABLE)
 		pg_fatal("data checksums are already disabled in cluster");
 
@@ -645,7 +645,7 @@ main(int argc, char *argv[])
 	if (mode == PG_MODE_ENABLE || mode == PG_MODE_DISABLE)
 	{
 		ControlFile->data_checksum_version =
-			(mode == PG_MODE_ENABLE) ? PG_DATA_CHECKSUM_VERSION : 0;
+			(mode == PG_MODE_ENABLE) ? PG_DATA_CHECKSUM_VERSION : PG_DATA_CHECKSUM_OFF;
 
 		if (do_sync)
 		{

--- a/src/bin/pg_combinebackup/pg_combinebackup.c
+++ b/src/bin/pg_combinebackup/pg_combinebackup.c
@@ -615,7 +615,7 @@ check_control_files(int n_backups, char **backup_dirs)
 {
 	int			i;
 	uint64		system_identifier = 0;	/* placate compiler */
-	uint32		data_checksum_version = 0;	/* placate compiler */
+	uint32		data_checksum_version = PG_DATA_CHECKSUM_OFF;	/* placate compiler */
 	bool		data_checksum_mismatch = false;
 
 	/* Try to read each control file in turn, last to first. */
@@ -652,7 +652,7 @@ check_control_files(int n_backups, char **backup_dirs)
 		 */
 		if (i == n_backups - 1)
 			data_checksum_version = control_file->data_checksum_version;
-		else if (data_checksum_version != 0 &&
+		else if (data_checksum_version != PG_DATA_CHECKSUM_OFF &&
 				 data_checksum_version != control_file->data_checksum_version)
 			data_checksum_mismatch = true;
 

--- a/src/bin/pg_upgrade/controldata.c
+++ b/src/bin/pg_upgrade/controldata.c
@@ -206,7 +206,7 @@ get_control_data(ClusterInfo *cluster)
 	/* Only in <= 9.2 */
 	if (GET_MAJOR_VERSION(cluster->major_version) <= 902)
 	{
-		cluster->controldata.data_checksum_version = 0;
+		cluster->controldata.data_checksum_version = PG_DATA_CHECKSUM_OFF;
 		got_data_checksum_version = true;
 	}
 
@@ -749,11 +749,11 @@ check_control_data(ControlData *oldctrl,
 	 * We might eventually allow upgrades from checksum to no-checksum
 	 * clusters.
 	 */
-	if (oldctrl->data_checksum_version == 0 &&
-		newctrl->data_checksum_version != 0)
+	if (oldctrl->data_checksum_version == PG_DATA_CHECKSUM_OFF &&
+		newctrl->data_checksum_version != PG_DATA_CHECKSUM_OFF)
 		pg_fatal("old cluster does not use data checksums but the new one does");
-	else if (oldctrl->data_checksum_version != 0 &&
-			 newctrl->data_checksum_version == 0)
+	else if (oldctrl->data_checksum_version != PG_DATA_CHECKSUM_OFF &&
+			 newctrl->data_checksum_version == PG_DATA_CHECKSUM_OFF)
 		pg_fatal("old cluster uses data checksums but the new one does not");
 	else if (oldctrl->data_checksum_version != newctrl->data_checksum_version)
 		pg_fatal("old and new cluster pg_controldata checksum versions do not match");

--- a/src/bin/pg_upgrade/file.c
+++ b/src/bin/pg_upgrade/file.c
@@ -331,7 +331,7 @@ rewriteVisibilityMap(const char *fromfile, const char *tofile,
 				break;
 
 			/* Set new checksum for visibility map page, if enabled */
-			if (new_cluster.controldata.data_checksum_version != 0)
+			if (new_cluster.controldata.data_checksum_version != PG_DATA_CHECKSUM_OFF)
 				((PageHeader) new_vmbuf.data)->pd_checksum =
 					pg_checksum_page(new_vmbuf.data, new_blkno);
 


### PR DESCRIPTION
This allows data checksums to be enabled, or disabled, in a running cluster without restricting access to the cluster during processing.

Data checksums could prior to this only be enabled during initdb or when the cluster is offline using the pg_checksums app. This commit introduce functionality to enable, or disable, data checksums while the cluster is running regardless of how it was initialized.

A background worker launcher process is responsible for launching a dynamic per-database background worker which will mark all buffers dirty for all relation with storage in order for them to have data checksums calculated on write.  Once all relations in all databases have been processed, the data_checksums state will be set to on and the cluster will at that point be identical to one which had data checksums enabled during initialization or via offline processing.

When data checksums are being enabled, concurrent I/O operations from backends other than the data checksums worker will write the checksums but not verify them on reading.  Only when all backends have absorbed the procsignalbarrier for setting data_checksums to on will they also start verifying checksums on reading.  The same process is repeated during disabling; all backends write checksums but do not verify them until the barrier for setting the state to off has been absorbed by all.  This in-progress state is used to ensure there are no false negatives (or positives) due to reading a checksum which is not in sync with the page.

A new testmodule, test_checksums, is introduced with an extensive set of tests covering both online and offline data checksum mode changes.  The tests which run concurrent pgbdench during online processing are gated behind the PG_TEST_EXTRA flag due to being very expensive to run.  Two levels of PG_TEST_EXTRA flags exist to turn on a subset of the expensive tests, or the full suite of multiple runs.

This work is based on an earlier version of this patch which was reviewed by among others Heikki Linnakangas, Robert Haas, Andres Freund, Tomas Vondra, Michael Banck and Andrey Borodin.  During the work on this new version, Tomas Vondra has given invaluable assistance with not only coding and reviewing but very in-depth testing.

Author: Daniel Gustafsson <daniel@yesql.se>
Author: Magnus Hagander <magnus@hagander.net>

Reviewed-by: Tomas Vondra <tomas@vondra.me>
Reviewed-by: Andres Freund <andres@anarazel.de>
Reviewed-by: Heikki Linnakangas <hlinnaka@iki.fi>
Discussion: https://postgr.es/m/CABUevExz9hUUOLnJVr2kpw9Cx=o4MCr1SVKwbupzuxP7ckNutA@mail.gmail.com
Discussion: https://postgr.es/m/20181030051643.elbxjww5jjgnjaxg@alap3.anarazel.de
Discussion: https://postgr.es/m/CABUevEwE3urLtwxxqdgd5O2oQz9J717ZzMbh+ziCSa5YLLU_BA@mail.gmail.com