### PR TITLE
Remove incorrect OpenSSL feature guards

### DIFF
--- a/src/backend/libpq/be-secure-openssl.c
+++ b/src/backend/libpq/be-secure-openssl.c
@@ -48,9 +48,7 @@
 #include <openssl/bn.h>
 #include <openssl/conf.h>
 #include <openssl/dh.h>
-#ifndef OPENSSL_NO_ECDH
 #include <openssl/ec.h>
-#endif
 #include <openssl/x509v3.h>
 
 /*
@@ -2115,7 +2113,6 @@ initialize_dh(SSL_CTX *context, bool isServerStart)
 static bool
 initialize_ecdh(SSL_CTX *context, bool isServerStart)
 {
-#ifndef OPENSSL_NO_ECDH
 	if (SSL_CTX_set1_groups_list(context, SSLECDHCurve) != 1)
 	{
 		/*
@@ -2133,7 +2130,6 @@ initialize_ecdh(SSL_CTX *context, bool isServerStart)
 				errhint("Ensure that each group name is spelled correctly and supported by the installed version of OpenSSL."));
 		return false;
 	}
-#endif
 
 	return true;
 }

--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -52,7 +52,7 @@ bool		ssl_loaded_verify_locations = false;
 char	   *SSLCipherSuites = NULL;
 char	   *SSLCipherList = NULL;
 
-/* GUC variable for default ECHD curve. */
+/* GUC variable for default ECDH curve. */
 char	   *SSLECDHCurve;
 
 /* GUC variable: if false, prefer client ciphers */


### PR DESCRIPTION
Commit 316472146 introduced support for ECDH key exchange with an ifdef guard to ensure support in the underlying OpenSSL installation.  Commit 10bf4fc2c in OpenSSL removed this guard in 2015 which effectively made our check a no-op.  There has been no complaints that this doesn't work and OpenSSL installations without ECDH support are likely very rare, so remove the checks rather than re-implementing support.

Also fix a typo introduced in the original commit which had survived till this day.

Author: Daniel Gustafsson <daniel@yesql.se>
Discussion: https://postgr.es/m/...