### PR TITLE
Support OpenSSL 4

### DIFF
--- a/contrib/sslinfo/sslinfo.c
+++ b/contrib/sslinfo/sslinfo.c
@@ -24,8 +24,8 @@ PG_MODULE_MAGIC_EXT(
 					.version = PG_VERSION
 );
 
-static Datum X509_NAME_field_to_text(X509_NAME *name, text *fieldName);
-static Datum ASN1_STRING_to_text(ASN1_STRING *str);
+static Datum X509_NAME_field_to_text(const X509_NAME *name, text *fieldName);
+static Datum ASN1_STRING_to_text(const ASN1_STRING *str);
 
 /*
  * Function context for data persisting over repeated calls.
@@ -148,7 +148,7 @@ ssl_client_serial(PG_FUNCTION_ARGS)
  * function.
  */
 static Datum
-ASN1_STRING_to_text(ASN1_STRING *str)
+ASN1_STRING_to_text(const ASN1_STRING *str)
 {
 	BIO		   *membuf;
 	size_t		size;
@@ -194,12 +194,12 @@ ASN1_STRING_to_text(ASN1_STRING *str)
  * part of name
  */
 static Datum
-X509_NAME_field_to_text(X509_NAME *name, text *fieldName)
+X509_NAME_field_to_text(const X509_NAME *name, text *fieldName)
 {
 	char	   *string_fieldname;
 	int			nid,
 				index;
-	ASN1_STRING *data;
+	const ASN1_STRING *data;
 
 	string_fieldname = text_to_cstring(fieldName);
 	nid = OBJ_txt2nid(string_fieldname);
@@ -209,7 +209,7 @@ X509_NAME_field_to_text(X509_NAME *name, text *fieldName)
 				 errmsg("invalid X.509 field name: \"%s\"",
 						string_fieldname)));
 	pfree(string_fieldname);
-	index = X509_NAME_get_index_by_NID(name, nid, -1);
+	index = X509_NAME_get_index_by_NID(unconstify(X509_NAME *, name), nid, -1);
 	if (index < 0)
 		return (Datum) 0;
 	data = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, index));
@@ -421,8 +421,8 @@ ssl_extension_info(PG_FUNCTION_ARGS)
 		HeapTuple	tuple;
 		Datum		result;
 		BIO		   *membuf;
-		X509_EXTENSION *ext;
-		ASN1_OBJECT *obj;
+		const X509_EXTENSION *ext;
+		const ASN1_OBJECT *obj;
 		int			nid;
 		int			len;
 
@@ -435,7 +435,7 @@ ssl_extension_info(PG_FUNCTION_ARGS)
 
 		/* Get the extension from the certificate */
 		ext = X509_get_ext(cert, call_cntr);
-		obj = X509_EXTENSION_get_object(ext);
+		obj = X509_EXTENSION_get_object(unconstify(X509_EXTENSION *, ext));
 
 		/* Get the extension name */
 		nid = OBJ_obj2nid(obj);
@@ -448,7 +448,7 @@ ssl_extension_info(PG_FUNCTION_ARGS)
 		nulls[0] = false;
 
 		/* Get the extension value */
-		if (X509V3_EXT_print(membuf, ext, 0, 0) <= 0)
+		if (X509V3_EXT_print(membuf, unconstify(X509_EXTENSION *, ext), 0, 0) <= 0)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("could not print extension value in certificate at position %d",

--- a/src/backend/libpq/be-secure-openssl.c
+++ b/src/backend/libpq/be-secure-openssl.c
@@ -104,7 +104,7 @@ static void host_context_cleanup_cb(void *arg);
 static int	sni_clienthello_cb(SSL *ssl, int *al, void *arg);
 #endif
 
-static char *X509_NAME_to_cstring(X509_NAME *name);
+static char *X509_NAME_to_cstring(const X509_NAME *name);
 
 static SSL_CTX *SSL_context = NULL;
 static MemoryContext SSL_hosts_memcxt = NULL;
@@ -1069,18 +1069,18 @@ aloop:
 	if (port->peer != NULL)
 	{
 		int			len;
-		X509_NAME  *x509name = X509_get_subject_name(port->peer);
+		const X509_NAME *x509name = X509_get_subject_name(port->peer);
 		char	   *peer_dn;
 		BIO		   *bio = NULL;
 		BUF_MEM    *bio_buf = NULL;
 
-		len = X509_NAME_get_text_by_NID(x509name, NID_commonName, NULL, 0);
+		len = X509_NAME_get_text_by_NID(unconstify(X509_NAME *, x509name), NID_commonName, NULL, 0);
 		if (len != -1)
 		{
 			char	   *peer_cn;
 
 			peer_cn = MemoryContextAlloc(TopMemoryContext, len + 1);
-			r = X509_NAME_get_text_by_NID(x509name, NID_commonName, peer_cn,
+			r = X509_NAME_get_text_by_NID(unconstify(X509_NAME *, x509name), NID_commonName, peer_cn,
 										  len + 1);
 			peer_cn[len] = '\0';
 			if (r != len)
@@ -2329,14 +2329,14 @@ be_tls_get_certificate_hash(Port *port, size_t *len)
  *
  */
 static char *
-X509_NAME_to_cstring(X509_NAME *name)
+X509_NAME_to_cstring(const X509_NAME *name)
 {
 	BIO		   *membuf = BIO_new(BIO_s_mem());
 	int			i,
 				nid,
 				count = X509_NAME_entry_count(name);
-	X509_NAME_ENTRY *e;
-	ASN1_STRING *v;
+	const X509_NAME_ENTRY *e;
+	const ASN1_STRING *v;
 	const char *field_name;
 	size_t		size;
 	char		nullterm;

--- a/src/interfaces/libpq/fe-secure-openssl.c
+++ b/src/interfaces/libpq/fe-secure-openssl.c
@@ -67,7 +67,7 @@
 
 static int	verify_cb(int ok, X509_STORE_CTX *ctx);
 static int	openssl_verify_peer_name_matches_certificate_name(PGconn *conn,
-															  ASN1_STRING *name_entry,
+															  const ASN1_STRING *name_entry,
 															  char **store_name);
 static int	openssl_verify_peer_name_matches_certificate_ip(PGconn *conn,
 															ASN1_OCTET_STRING *addr_entry,
@@ -467,7 +467,8 @@ cert_cb(SSL *ssl, void *arg)
  * into a plain C string.
  */
 static int
-openssl_verify_peer_name_matches_certificate_name(PGconn *conn, ASN1_STRING *name_entry,
+openssl_verify_peer_name_matches_certificate_name(PGconn *conn,
+												  const ASN1_STRING *name_entry,
 												  char **store_name)
 {
 	int			len;
@@ -650,14 +651,14 @@ pgtls_verify_peer_name_matches_certificate_guts(PGconn *conn,
 	 */
 	if (check_cn)
 	{
-		X509_NAME  *subject_name;
+		const X509_NAME *subject_name;
 
 		subject_name = X509_get_subject_name(conn->peer);
 		if (subject_name != NULL)
 		{
 			int			cn_index;
 
-			cn_index = X509_NAME_get_index_by_NID(subject_name,
+			cn_index = X509_NAME_get_index_by_NID(unconstify(X509_NAME *, subject_name),
 												  NID_commonName, -1);
 			if (cn_index >= 0)
 			{

--- a/src/test/ssl/t/001_ssltests.pl
+++ b/src/test/ssl/t/001_ssltests.pl
@@ -885,7 +885,7 @@ $node->connect_fails(
 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt "
 	  . sslkey('client-revoked.key'),
 	"certificate authorization fails with revoked client cert",
-	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+	expected_stderr => qr!SSL error: (ssl[a-z0-9/]*|tls) alert certificate revoked!,
 	log_like => [
 		qr{Client certificate verification failed at depth 0: certificate revoked},
 		qr{Failed certificate data \(unverified\): subject "/CN=ssltestuser", serial number \d+, issuer "/CN=Test CA for PostgreSQL SSL regression test client certs"},
@@ -987,7 +987,7 @@ $node->connect_fails(
 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt "
 	  . sslkey('client-revoked.key'),
 	"certificate authorization fails with revoked client cert with server-side CRL directory",
-	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+	expected_stderr => qr!SSL error: (ssl[a-z0-9/]*|tls) alert certificate revoked!,
 	log_like => [
 		qr{Client certificate verification failed at depth 0: certificate revoked},
 		qr{Failed certificate data \(unverified\): subject "/CN=ssltestuser", serial number \d+, issuer "/CN=Test CA for PostgreSQL SSL regression test client certs"},
@@ -998,7 +998,7 @@ $node->connect_fails(
 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked-utf8.crt "
 	  . sslkey('client-revoked-utf8.key'),
 	"certificate authorization fails with revoked UTF-8 client cert with server-side CRL directory",
-	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+	expected_stderr => qr!SSL error: (ssl[a-z0-9/]*|tls) alert certificate revoked!,
 	log_like => [
 		qr{Client certificate verification failed at depth 0: certificate revoked},
 		qr{Failed certificate data \(unverified\): subject "/CN=\\xce\\x9f\\xce\\xb4\\xcf\\x85\\xcf\\x83\\xcf\\x83\\xce\\xad\\xce\\xb1\\xcf\\x82", serial number \d+, issuer "/CN=Test CA for PostgreSQL SSL regression test client certs"},


### PR DESCRIPTION
OpenSSL 4.0.0 changed some parameters and returnvalues to const, so we need to update our declarations and subsequently cast away const- ness from a few callsites to make libpq build without warnings. This is tested with OpenSSL 1.1.1 through 4.0.0 as well as with LibreSSL.

There is also an errormessage change in OpenSSL 4.0.0 which needs to be covered by our testharness.

Author: Daniel Gustafsson <daniel@yesql.se>
Discussion: https://postgr.es/m/066B07BB-85FA-487C-BE8C-40F791CFC3C4@yesql.se